### PR TITLE
Modernize cmake and add install target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/build/*
+
 # Prerequisites
 *.d
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
+include(GNUInstallDirs)
 
 option(BUILD_EXAMPLES "Build examples" OFF)
 
@@ -25,12 +26,21 @@ set_target_properties(${PROJECT_NAME}
         DEBUG_POSTFIX "-d"
 )
 
-# example: RigidBodyStreaming
-add_executable(RigidBodyStreaming
-  RigidBodyStreaming/RigidBodyStreaming.cpp
+# ----------- INSTALL & EXPORT -----------
+
+# 'make install' to the correct locations (provided by GNUInstallDirs).
+install(
+	TARGETS ${PROJECT_NAME}
+	EXPORT ${PROJECT_NAME}-targets
+    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR} # This is for Windows
 )
-target_link_libraries(RigidBodyStreaming
-  qualisys_cpp_sdk
+# Copy along headers
+set(INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+install(
+    CODE "file( GLOB HEADERS \"${CMAKE_CURRENT_SOURCE_DIR}/*.h*\" )"
+    CODE "file( INSTALL \${HEADERS} DESTINATION \"${INSTALL_INCLUDE_DIR}\" )"
 )
 
 # example: RigidBodyStreaming

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,28 @@
 cmake_minimum_required(VERSION 3.5)
 
+option(BUILD_EXAMPLES "Build examples" OFF)
+
 project(qualisys_cpp_sdk)
-
-# Enable C++11
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-include_directories(
-  ${CMAKE_CURRENT_LIST_DIR}
-)
 
 add_library(qualisys_cpp_sdk
   Markup.cpp
   Network.cpp
   RTPacket.cpp
   RTProtocol.cpp
+)
+target_include_directories( ${PROJECT_NAME} 
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+target_link_libraries( ${PROJECT_NAME}
+    PRIVATE $<$<STREQUAL:"${CMAKE_CXX_COMPILER_ID}","MSVC">:ws2_32.lib>
+)
+# Enable C++11
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+set_target_properties(${PROJECT_NAME} 
+    PROPERTIES 
+    	CXX_STANDARD_REQUIRED ON
+    	CXX_EXTENSIONS OFF
+        DEBUG_POSTFIX "-d"
 )
 
 # example: RigidBodyStreaming
@@ -26,6 +33,15 @@ target_link_libraries(RigidBodyStreaming
   qualisys_cpp_sdk
 )
 
+# example: RigidBodyStreaming
+if(BUILD_EXAMPLES)
+    add_executable(RigidBodyStreaming
+        RigidBodyStreaming/RigidBodyStreaming.cpp
+    )
+    target_link_libraries(RigidBodyStreaming
+        qualisys_cpp_sdk
+    )
+endif()
 # # example: RTClientExample
 # add_executable(RTClientExample
 #   RTClientExample/Input.cpp

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@ Qualisys Realtime SDK
 
 C++ package with SDK and examples
 
-# Compile on Windows
+# Build with Visual Studio
 
 Build RTClientSDK solution in Visual Studio 2017.
 
-# Compile on Ubuntu
+# Build with CMake (Windows & Linux)
 
-Tested on Ubuntu 16/18
+* _Tested with GCC 7._
+* _Tested with VS 2017._
 
 ```
 mkdir build
 cd build
-cmake ..
-make
+cmake .. -DBUILD_EXAMPLES=ON
+cmake --build .
 ```
-


### PR DESCRIPTION
* Replaced usage of deprecated commands with "modern" target specific ones.
* Fixed cmake build for MSVC.
* Added install target.
* Made building of examples optional.