### PR TITLE
Added result changing parameters to rt server settings

### DIFF
--- a/RTClientExample/OutputSettings.cpp
+++ b/RTClientExample/OutputSettings.cpp
@@ -591,7 +591,8 @@ void COutput::Print3DSettings(CRTProtocol* poRTProtocol)
     for (unsigned int iLabel = 0; iLabel < nCount; iLabel++)
     {
         printf("Marker %2d: %s", iLabel + 1, poRTProtocol->Get3DLabelName(iLabel));
-        printf("   Color: %.6X\n", poRTProtocol->Get3DLabelColor(iLabel));
+        printf("   Color: %.6X", poRTProtocol->Get3DLabelColor(iLabel));
+        printf("   Type:  %s\n", poRTProtocol->Get3DTrajectoryType(iLabel));
     }
 
     nCount = poRTProtocol->Get3DBoneCount();
@@ -717,6 +718,8 @@ void COutput::PrintGazeVectorSettings(CRTProtocol* poRTProtocol)
             printf("Gaze vector #%d\n", iVector + 1);
             printf("  Name:  %s\n", poRTProtocol->GetGazeVectorName(iVector));
             printf("  Frequency: %.1f\n", poRTProtocol->GetGazeVectorFrequency(iVector));
+            printf("  Hardware sync: %s\n", poRTProtocol->GetGazeVectorHardwareSyncUsed(iVector) ? "True" : "False");
+            printf("  Filter: %s\n", poRTProtocol->GetGazeVectorFilterUsed(iVector) ? "True" : "False");
             printf("\n");
         }
     }
@@ -735,6 +738,7 @@ void COutput::PrintEyeTrackerSettings(CRTProtocol* poRTProtocol)
             printf("Eye tracker #%d\n", eyeTracker + 1);
             printf("  Name:  %s\n", poRTProtocol->GetEyeTrackerName(eyeTracker));
             printf("  Frequency: %.1f\n", poRTProtocol->GetEyeTrackerFrequency(eyeTracker));
+            printf("  Hardware sync: %s\n", poRTProtocol->GetGazeVectorHardwareSyncUsed(eyeTracker) ? "True" : "False");
             printf("\n");
         }
     }

--- a/RTProtocol.h
+++ b/RTProtocol.h
@@ -345,6 +345,7 @@ public:
     {
         std::string  oName;
         unsigned int nRGBColor;
+        std::string type;
     };
 
     struct SSettingsBone
@@ -403,12 +404,15 @@ public:
     {
         std::string    name;
         float          frequency;
+        bool           hwSync;
+        bool           filter;
     };
 
     struct SEyeTracker
     {
         std::string    name;
         float          frequency;
+        bool           hwSync;
     };
 
     struct SAnalogDevice 
@@ -794,6 +798,8 @@ public:
     const char*  Get3DLabelName(unsigned int nMarkerIndex) const;
     unsigned int Get3DLabelColor(unsigned int nMarkerIndex) const;
 
+    const char*  Get3DTrajectoryType(unsigned int nMarkerIndex) const;
+
     unsigned int Get3DBoneCount() const;
     const char*  Get3DBoneFromName(unsigned int boneIndex) const;
     const char*  Get3DBoneToName(unsigned int boneIndex) const;
@@ -810,10 +816,13 @@ public:
     unsigned int GetGazeVectorCount() const;
     const char*  GetGazeVectorName(unsigned int nGazeVectorIndex) const;
     float        GetGazeVectorFrequency(unsigned int nGazeVectorIndex) const;
+    bool         GetGazeVectorHardwareSyncUsed(unsigned int nGazeVectorIndex) const;
+    bool         GetGazeVectorFilterUsed(unsigned int nGazeVectorIndex) const;
 
     unsigned int GetEyeTrackerCount() const;
     const char*  GetEyeTrackerName(unsigned int nEyeTrackerIndex) const;
     float        GetEyeTrackerFrequency(unsigned int nEyeTrackerIndex) const;
+    bool         GetEyeTrackerHardwareSyncUsed(unsigned int nEyeTrackerIndex) const;
 
     unsigned int GetAnalogDeviceCount() const;
     bool         GetAnalogDevice(unsigned int nDeviceIndex, unsigned int &nDeviceID, unsigned int &nChannels,


### PR DESCRIPTION
Added result changing parameters to 3D, eye tracker and gaze vector settings. Also updated RTClientSDK and RTClientExample with the new settings. The RT server documentation is also updated. But it is located in its own repository.

**3D settings**
Added Trajectory_Type. Possible values:
Measured, Gap-filled, Virtual, Edited, Mixed, Measured Slave, Gap-filled Slave, Virtual Slave, Edited Slave.
```xml
<The_3D>
    <AxisUpwards></AxisUpwards>
    <CalibrationTime></CalibrationTime>
    <Labels></Labels>
    <Label>
        <Name></Name>
        <RGBColor></RGBColor>
        <Trajectory_Type></Trajectory_Type>
    </Label>
    <Bones>
        <Bone From To Color/>
    </Bones>
</The_3D>
```
**Eye tracker**
Added Hardware_Sync. Possible values: True and False.
```xml
<Eye_Tracker>
    <Device>
        <Name></Name>
        <Frequency></Frequency>
        <Hardware_Sync></Hardware_Sync>
    </Device>
</Eye_Tracker>
```
**Gaze vector**
Added Hardware_Sync and Filter. Possible values: True and False.
```xml
<Gaze_Vector>
    <Vector>
        <Name></Name>
        <Frequency></Frequency>
        <Hardware_Sync></Hardware_Sync>
        <Filter></Filter>
    </Vector>
</Gaze_Vector>
```