### PR TITLE
Replaced ReceiveRTPacket with Receive which can detect remote host shutdown.

### DIFF
--- a/Network.h
+++ b/Network.h
@@ -12,13 +12,31 @@
 class CNetwork
 {
 public:
+    enum class ResponseType
+    {
+        success,
+        timeout,
+        disconnect,
+        error
+    };
+
+    struct Response
+    {
+        int received;
+        ResponseType type;
+
+        Response(ResponseType type_, int received_) : received(received_), type(type_) {}
+        operator bool() { return type == ResponseType::success; }
+        operator ResponseType() { return type; }
+    };
+
     CNetwork();
     ~CNetwork();
     bool  Connect(const char* pServerAddr, unsigned short nPort);
     void  Disconnect();
     bool  Connected() const;
     bool  CreateUDPSocket(unsigned short &nUDPPort, bool bBroadcast = false);
-    int   Receive(char* rtDataBuff, int nDataBufSize, bool bHeader, int nTimeout, unsigned int *ipAddr = nullptr);
+    Response   Receive(char* rtDataBuff, int nDataBufSize, bool bHeader, int nTimeout, unsigned int *ipAddr = nullptr);
     bool  Send(const char* pSendBuf, int nSize);
     bool  SendUDPBroadcast(const char* pSendBuf, int nSize, short nPort, unsigned int nFilterAddr = 0);
     char* GetErrorString();

--- a/RTClientExample/Operations.cpp
+++ b/RTClientExample/Operations.cpp
@@ -79,13 +79,13 @@ void COperations::MonitorEvents()
 
     while (mpoInput->CheckKeyPressed() == false)
     {
-        int nRecv = mpoRTProtocol->ReceiveRTPacket(ePacketType, false);
+        auto response = mpoRTProtocol->Receive(ePacketType, false);
 
-        if (nRecv == -1 || ePacketType == CRTPacket::PacketError)
+        if (response == CNetwork::ResponseType::error || ePacketType == CRTPacket::PacketError)
         {
             break;
         }
-        if (nRecv > 0 && ePacketType == CRTPacket::PacketEvent)
+        if (response == CNetwork::ResponseType::success && ePacketType == CRTPacket::PacketEvent)
         {
             printf("#%d ", nEventCount++);
 
@@ -789,7 +789,7 @@ void COperations::DataTransfer(CInput::EOperation operation)
             bAbort = (mpoRTProtocol->GetCurrentFrame(nComponentType, componentOptions) == false);
         }
 
-        if (mpoRTProtocol->ReceiveRTPacket(ePacketType, true) > 0)
+        if (mpoRTProtocol->Receive(ePacketType, true) == CNetwork::ResponseType::success)
         {
             switch (ePacketType) 
             {

--- a/RTProtocol.h
+++ b/RTProtocol.h
@@ -702,7 +702,9 @@ public:
     static std::vector<std::pair<unsigned int, std::string>> GetComponents(const std::string componentsString);
     static bool GetComponent(std::string componentStr, unsigned int &component, std::string &option);
 
-    int        ReceiveRTPacket(CRTPacket::EPacketType &eType, bool bSkipEvents = true, int nTimeout = cWaitForDataTimeout); // nTimeout < 0 : Blocking receive
+    [[deprecated("Replaced by Receive.")]]
+    int         ReceiveRTPacket(CRTPacket::EPacketType &eType, bool bSkipEvents = true, int nTimeout = cWaitForDataTimeout); // nTimeout < 0 : Blocking receive
+    CNetwork::ResponseType Receive(CRTPacket::EPacketType &eType, bool bSkipEvents = true, int nTimeout = cWaitForDataTimeout); // nTimeout < 0 : Blocking receive
     
 
     CRTPacket* GetRTPacket();

--- a/RigidBodyStreaming/RigidBodyStreaming.cpp
+++ b/RigidBodyStreaming/RigidBodyStreaming.cpp
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 
             CRTPacket::EPacketType packetType;
 
-            if (rtProtocol.ReceiveRTPacket(packetType, true) > 0)
+            if (rtProtocol.Receive(packetType, true) == CNetwork::ResponseType::success)
             {
                 if (packetType == CRTPacket::PacketData)
                 {


### PR DESCRIPTION
Changed `CNetwork::Receive` to return a response struct instead of an int. The struct contains an enum with: success, timeout, disconnect and error. And also number of received bytes. Previously there was no way of distinguishing between timeout and disconnect.

Depricated `CRTProtocol::ReceiveRTPacket` and replaced it with `CRTProtocol::Receive` which returns an enum with respone type (success, timeout, error and disconnect).