### PR TITLE
Merge latest upstream/qtm changes:

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2019 Qualisys AB
+Copyright (c) 2015-2021 Qualisys AB
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Network.cpp
+++ b/Network.cpp
@@ -58,6 +58,11 @@ CNetwork::CNetwork()
 
 CNetwork::~CNetwork()
 {
+    if (Connected()) 
+    {
+        Disconnect();
+    }
+
 #ifdef _WIN32
     WSACleanup();
 #endif

--- a/Network.h
+++ b/Network.h
@@ -2,11 +2,14 @@
 #define NETWORK_H
 
 #ifdef _WIN32
-	#define WIN32_LEAN_AND_MEAN
-	#include <winsock2.h>
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
+
+    #include <winsock2.h>
 #else
-	#define INVALID_SOCKET	-1
-	#define SOCKET int
+    #define INVALID_SOCKET -1
+    #define SOCKET int
 #endif
 
 #include <vector>

--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -1654,7 +1654,6 @@ bool CRTProtocol::ReadSettings(std::string settingsType, CMarkup &oXML)
     CRTPacket::EPacketType eType;
 
     mvsAnalogDeviceSettings.clear();
-
     auto sendStr = std::string("GetParameters ") + settingsType;
     if (!SendCommand(sendStr.c_str()))
     {
@@ -1662,6 +1661,7 @@ bool CRTProtocol::ReadSettings(std::string settingsType, CMarkup &oXML)
         return false;
     }
 
+retry:
     auto received = Receive(eType, true);
 
     if (received == CNetwork::ResponseType::timeout)
@@ -1679,12 +1679,13 @@ bool CRTProtocol::ReadSettings(std::string settingsType, CMarkup &oXML)
         if (eType == CRTPacket::PacketError)
         {
             sprintf(maErrorStr, "%s.", mpoRTPacket->GetErrorString());
+            return false;
         }
         else
         {
-            sprintf(maErrorStr, "GetParameters %s returned wrong packet type. Got type %d expected type 2.", settingsType.c_str(), eType);
+            goto retry;
+            //sprintf(maErrorStr, "GetParameters %s returned wrong packet type. Got type %d expected type 2.", settingsType.c_str(), eType);
         }
-        return false;
     }
 
     oXML.SetDoc(mpoRTPacket->GetXMLString());


### PR DESCRIPTION
* Automatically disconnect in CNetwork destructor.
* Fix bug where settings would fail to be fetched if streaming simultaneously.
* Only define `WIN32_LEAN_AND_MEAN` if not already defined.