### PR TITLE
Set C++14 in CMake (issue on aarch64 architecture).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ option(BUILD_EXAMPLES "Build examples" OFF)
 
 project(qualisys_cpp_sdk)
 
+
+
 add_library(qualisys_cpp_sdk
   Markup.cpp
   Network.cpp
@@ -18,7 +20,7 @@ target_link_libraries( ${PROJECT_NAME}
     PRIVATE $<$<STREQUAL:"${CMAKE_CXX_COMPILER_ID}","MSVC">:ws2_32.lib>
 )
 # Enable C++11
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 set_target_properties(${PROJECT_NAME} 
     PROPERTIES 
     	CXX_STANDARD_REQUIRED ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ option(BUILD_EXAMPLES "Build examples" OFF)
 
 project(qualisys_cpp_sdk)
 
-
-
 add_library(qualisys_cpp_sdk
   Markup.cpp
   Network.cpp


### PR DESCRIPTION
Hello,

I was trying to compile the SDK on an `NVIDIA Jetson TX2` (`aarch64` architecture) running `Ubuntu 18.04`, when I faced an error building the project. These are the build errors:

```
Scanning dependencies of target qualisys_cpp_sdk
[ 14%] Building CXX object CMakeFiles/qualisys_cpp_sdk.dir/Markup.cpp.o
[ 28%] Building CXX object CMakeFiles/qualisys_cpp_sdk.dir/Network.cpp.o
[ 42%] Building CXX object CMakeFiles/qualisys_cpp_sdk.dir/RTPacket.cpp.o
[ 57%] Building CXX object CMakeFiles/qualisys_cpp_sdk.dir/RTProtocol.cpp.o
/home/nvidia/programming-ws/qualisys_cpp_sdk/RTProtocol.cpp: In static member function ‘static const char* CRTProtocol::SkeletonDofToString(CRTProtocol::EDegreeOfFreedom)’:
/home/nvidia/programming-ws/qualisys_cpp_sdk/RTProtocol.cpp:6046:92: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
     auto it = std::find_if(DEGREES_OF_FREEDOM.begin(), DEGREES_OF_FREEDOM.end(), [&](const auto& DEGREE_OF_FREEDOM) { return (DEGREE_OF_FREEDOM.first == dof); });
                                                                                            ^~~~
/home/nvidia/programming-ws/qualisys_cpp_sdk/RTProtocol.cpp: In lambda function:
/home/nvidia/programming-ws/qualisys_cpp_sdk/RTProtocol.cpp:6046:145: error: request for member ‘first’ in ‘DEGREE_OF_FREEDOM’, which is of non-class type ‘const int’
     auto it = std::find_if(DEGREES_OF_FREEDOM.begin(), DEGREES_OF_FREEDOM.end(), [&](const auto& DEGREE_OF_FREEDOM) { return (DEGREE_OF_FREEDOM.first == dof); });
                                                                                                                                                 ^~~~~
/home/nvidia/programming-ws/qualisys_cpp_sdk/RTProtocol.cpp: In static member function ‘static CRTProtocol::EDegreeOfFreedom CRTProtocol::SkeletonStringToDof(const string&)’:
/home/nvidia/programming-ws/qualisys_cpp_sdk/RTProtocol.cpp:6059:92: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
     auto it = std::find_if(DEGREES_OF_FREEDOM.begin(), DEGREES_OF_FREEDOM.end(), [&](const auto& DEGREE_OF_FREEDOM) { return (DEGREE_OF_FREEDOM.second == str); });
                                                                                            ^~~~
/home/nvidia/programming-ws/qualisys_cpp_sdk/RTProtocol.cpp: In lambda function:
/home/nvidia/programming-ws/qualisys_cpp_sdk/RTProtocol.cpp:6059:145: error: request for member ‘second’ in ‘DEGREE_OF_FREEDOM’, which is of non-class type ‘const int’
     auto it = std::find_if(DEGREES_OF_FREEDOM.begin(), DEGREES_OF_FREEDOM.end(), [&](const auto& DEGREE_OF_FREEDOM) { return (DEGREE_OF_FREEDOM.second == str); });
```

From the errors, we can see that the use of `auto` is only available with `-std=c++14` on this platform.

Modifying `cxx_std_11` to `cxx_std_14` in `CMakeLists.txt` fixes the error.
And the build process is not affected by the modification (tested on `x86_64` architecture running `Ubuntu 20.04`).