### PR TITLE
from static to shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.8)
 project(qualisys_cpp_sdk)
 
 option(BUILD_EXAMPLES "Build examples" OFF)
+include(GNUInstallDirs)
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
         Markup.cpp
         Network.cpp
         RTPacket.cpp
@@ -11,7 +12,7 @@ add_library(${PROJECT_NAME}
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+        $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 target_link_libraries(${PROJECT_NAME}
@@ -28,8 +29,6 @@ set_target_properties(${PROJECT_NAME}
 )
 
 # ----------- INSTALL & EXPORT -----------
-
-include(GNUInstallDirs)
 
 set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
 


### PR DESCRIPTION
I have some linking issue related to the fact that the default compiled library is static.
```
/usr/bin/ld: $MY_CUSTOM_PATH/lib/libqualisys_cpp_sdk.a(RTProtocol.cpp.o): relocation R_X86_64_PC32 against symbol `_ZTVSt9basic_iosIcSt11char_traitsIcEE@@GLIBCXX_3.4' can not be used when making a shared object; recompile with -fPIC
```
Hence I created a default shared library instead of a static one and fix the install paths install on the library target in the CMakeLists.txt.

Let me know if you think I should create an option for linking the static/shared library.

Best