### PR TITLE
Fix installation paths.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(qualisys_cpp_sdk)
 
+include(GNUInstallDirs)
+
 option(${PROJECT_NAME}_BUILD_EXAMPLES "Build examples" OFF)
 option(${PROJECT_NAME}_BUILD_TESTS "Build tests" OFF)
 
@@ -46,7 +48,6 @@ set_target_properties(${PROJECT_NAME}
 
 # ----------- INSTALL & EXPORT -----------
 
-include(GNUInstallDirs)
 
 set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
 


### PR DESCRIPTION
GNUInstallDirs was not defined when target_include_directories was set. This caused it to be blank and the cmake target import failed. User projects importing the cmake target should use include qualisys_cpp_sdk/RTProtocol.h etc.