### PR TITLE
Added time out parameter to Save Capture with default of 30 seconds

### DIFF
--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -982,7 +982,7 @@ bool CRTProtocol::LoadCapture(const char* pFileName)
 }
 
 
-bool CRTProtocol::SaveCapture(const char* pFileName, bool bOverwrite, char* pNewFileName, int nSizeOfNewFileName)
+bool CRTProtocol::SaveCapture(const char* pFileName, bool bOverwrite, char* pNewFileName, int nSizeOfNewFileName, int nTimeOut)
 {
     char tTemp[100];
     char pResponseStr[256];
@@ -994,7 +994,7 @@ bool CRTProtocol::SaveCapture(const char* pFileName, bool bOverwrite, char* pNew
     {
         sprintf(tTemp, "Save %s%s", pFileName, bOverwrite ? " Overwrite" : "");
 
-        if (SendCommand(tTemp, pResponseStr))
+        if (SendCommand(tTemp, pResponseStr, nTimeOut))
         {
             if (strcmp(pResponseStr, "Measurement saved") == 0)
             {

--- a/RTProtocol.h
+++ b/RTProtocol.h
@@ -35,6 +35,7 @@ public:
     static const unsigned int cDefaultAutoDiscoverPort  = cDefaultBasePort + 4;
 
     static const unsigned int cWaitForDataTimeout        = 5000000;   // 5 s
+    static const unsigned int cWaitForSaveTimeout        = 30000000;  // 30 s
     static const unsigned int cWaitForCalibrationTimeout = 600000000; // 10 min
 
     static const unsigned int cComponent3d            = 0x000001;
@@ -706,7 +707,7 @@ public:
     bool       StopCapture();
     bool       Calibrate(const bool refine, SCalibration &calibrationResult, int timeout = cWaitForCalibrationTimeout);
     bool       LoadCapture(const char* pFileName);
-    bool       SaveCapture(const char* pFileName, bool bOverwrite, char* pNewFileName = nullptr, int nSizeOfNewFileName = 0, int nTimeout = 30000000); //Default timeout is 30 seconds
+    bool       SaveCapture(const char* pFileName, bool bOverwrite, char* pNewFileName = nullptr, int nSizeOfNewFileName = 0, int nTimeout = cWaitForSaveTimeout); //Default timeout is 30 seconds
     bool       LoadProject(const char* pFileName);
     bool       Reprocess();
 

--- a/RTProtocol.h
+++ b/RTProtocol.h
@@ -706,7 +706,7 @@ public:
     bool       StopCapture();
     bool       Calibrate(const bool refine, SCalibration &calibrationResult, int timeout = cWaitForCalibrationTimeout);
     bool       LoadCapture(const char* pFileName);
-    bool       SaveCapture(const char* pFileName, bool bOverwrite, char* pNewFileName = nullptr, int nSizeOfNewFileName = 0);
+    bool       SaveCapture(const char* pFileName, bool bOverwrite, char* pNewFileName = nullptr, int nSizeOfNewFileName = 0, int nTimeout = 30000000); //Default timeout is 30 seconds
     bool       LoadProject(const char* pFileName);
     bool       Reprocess();
 


### PR DESCRIPTION
Issue
Send command has a default timeout of 5 seconds. This can be to short time for a save.

Solution
Added a timeout parameter to the SaveCapture command so the timeout can be configured. To keep compability with old code the default value is set to 30 seconds.