### PR TITLE
Fix Vulnerability In 'x_TextToDoc' Function

### DIFF
--- a/Markup.cpp
+++ b/Markup.cpp
@@ -692,7 +692,7 @@ std::string CMarkup::x_GetData(int iPos) const
 	return "";
 }
 
-std::string CMarkup::x_TextToDoc(const char* szText, bool bAttrib) const
+std::string CMarkup::x_TextToDoc(const char* szText, bool bAttrib)
 {
 	// Convert text as seen outside XML document to XML friendly
 	// replacing special characters with ampersand escape codes
@@ -708,43 +708,26 @@ std::string CMarkup::x_TextToDoc(const char* szText, bool bAttrib) const
 	// &quot; double quote
 	//
 	static const char* szaReplace[] = { "&lt;", "&amp;", "&gt;", "&apos;", "&quot;" };
-	const char* pFind = bAttrib ? "<&>\'\"" : "<&>";
-	std::string csText;
-	const char* pSource = szText;
-	int nDestSize = (int)strlen(pSource);
-	nDestSize += nDestSize / 10 + 7;
-	char* pDest = GetBuffer(csText, nDestSize);
-	int nLen = 0;
-	char cSource = *pSource;
-	const char* pFound;
-	while (cSource)
+	static const char* pFind = bAttrib ? "<&>\'\"" : "<&>";
+	std::string result;
+	result.reserve(strlen(szText) + (strlen(szText) / 10) + 7);
+
+	for (const char* p = szText; *p; ++p)
 	{
-		if (nLen > nDestSize - 6)
+		const char* found = strchr(pFind, *p);
+		if (found)
 		{
-			ReleaseBuffer(csText, nLen);
-			nDestSize *= 2;
-			pDest = GetBuffer(csText, nDestSize);
-		}
-		if ((pFound = strchr(pFind,cSource)) != NULL)
-		{
-			pFound = szaReplace[pFound-pFind];
-#ifdef _WIN32
-			strcpy_s(&pDest[nLen], nDestSize, pFound);
-#else
-			strncpy(&pDest[nLen], pFound, nDestSize);
-#endif
-			nLen += (int)strlen(pFound);
+			// Append appropriate replacement string
+			result += szaReplace[found - pFind];
 		}
 		else
 		{
-			pDest[nLen] = *pSource;
-			nLen += 1; //_tclen(pSource);
+			// Append original char
+			result += *p;
 		}
-		pSource += 1; //_tclen(pSource);
-		cSource = *pSource;
 	}
-	ReleaseBuffer(csText, nLen);
-	return csText;
+
+	return result;
 }
 
 std::string CMarkup::x_TextFromDoc(int nLeft, int nRight) const

--- a/Markup.cpp
+++ b/Markup.cpp
@@ -692,7 +692,7 @@ std::string CMarkup::x_GetData(int iPos) const
 	return "";
 }
 
-std::string CMarkup::x_TextToDoc(const char* szText, bool bAttrib)
+std::string CMarkup::x_TextToDoc(const char* szText, bool bAttrib) const
 {
 	// Convert text as seen outside XML document to XML friendly
 	// replacing special characters with ampersand escape codes

--- a/Markup.h
+++ b/Markup.h
@@ -153,7 +153,7 @@ protected:
 	int x_ParseNode(TokenPos& token);
 	void x_DocChange(int nLeft, int nReplace, const std::string& csInsert);
 	void x_Adjust(int iPos, int nShift, bool bAfterPos = false);
-	std::string x_TextToDoc(const char* szText, bool bAttrib = false);
+	std::string x_TextToDoc(const char* szText, bool bAttrib = false) const;
 	std::string x_TextFromDoc(int nLeft, int nRight) const;
 
 protected:

--- a/Markup.h
+++ b/Markup.h
@@ -153,7 +153,7 @@ protected:
 	int x_ParseNode(TokenPos& token);
 	void x_DocChange(int nLeft, int nReplace, const std::string& csInsert);
 	void x_Adjust(int iPos, int nShift, bool bAfterPos = false);
-	std::string x_TextToDoc(const char* szText, bool bAttrib = false) const;
+	std::string x_TextToDoc(const char* szText, bool bAttrib = false);
 	std::string x_TextFromDoc(int nLeft, int nRight) const;
 
 protected:


### PR DESCRIPTION
It was pointed out by [cktii](https://github.com/cktii) in [THIS](https://github.com/qualisys/qualisys_cpp_sdk/issues/49) issue that `CMarkup::x_TextToDoc` contains a vulnerability.

This PR fixes that issue by modifying the code to utilize `std::string`.

**NOTE:** This PR also solves a problem described in [THIS](https://github.com/qualisys/qualisys_cpp_sdk/issues/34) issue.