### PR TITLE
Added version fallback behaviour

### DIFF
--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -53,6 +53,38 @@ namespace
         std::make_pair(CRTProtocol::EDegreeOfFreedom::TranslationY, "TranslationY"),
         std::make_pair(CRTProtocol::EDegreeOfFreedom::TranslationZ, "TranslationZ")
     };
+
+    struct RTVersion
+    {
+        int major = MAJOR_VERSION;
+        int minor = MINOR_VERSION;
+
+        // Returns a list of rt protocol version which are supported by the current SDK, 
+        // including an initial version by the function argument. (The initial version is not checked for compatibility)
+        // The list is sorted high to low and contains only unique elements.
+        static std::vector<RTVersion> VersionList(const RTVersion& initial)
+        {
+            // Valid versions added from high to low
+            std::vector<RTVersion> versions {
+                {MAJOR_VERSION, MINOR_VERSION},
+                {1, 25},
+                {1, 24},
+                {1, 23},
+            };
+
+            // Remove higher versions
+            versions.erase(
+                std::remove_if(versions.begin(), versions.end(), [&](const RTVersion& v) {
+                    return v.major > initial.major || (v.major == initial.major && v.minor >= initial.minor);
+                }),
+                versions.end()
+            );
+
+            versions.insert(versions.begin(), initial);
+
+            return versions;
+        }
+    };
 }
 
 unsigned int CRTProtocol::GetSystemFrequency() const
@@ -92,9 +124,8 @@ CRTProtocol::~CRTProtocol()
     }
 } // ~CRTProtocol
 
-
 bool CRTProtocol::Connect(const char* pServerAddr, unsigned short nPort, unsigned short* pnUDPServerPort,
-                          int nMajorVersion, int nMinorVersion, bool bBigEndian)
+                          int nMajorVersion, int nMinorVersion, bool bBigEndian, bool bNegotiateVersion)
 {
     CRTPacket::EPacketType eType;
     std::string            tempStr;
@@ -102,7 +133,6 @@ bool CRTProtocol::Connect(const char* pServerAddr, unsigned short nPort, unsigne
 
     mbBigEndian = bBigEndian;
     mbIsMaster = false;
-
     mnMajorVersion = 1;
     if ((nMajorVersion == 1) && (nMinorVersion == 0))
     {
@@ -125,6 +155,7 @@ bool CRTProtocol::Connect(const char* pServerAddr, unsigned short nPort, unsigne
     {
         delete mpoRTPacket;
     }
+
     mpoRTPacket = new CRTPacket(nMajorVersion, nMinorVersion, bBigEndian);
 
     if (mpoRTPacket == nullptr)
@@ -159,38 +190,51 @@ bool CRTProtocol::Connect(const char* pServerAddr, unsigned short nPort, unsigne
                 const std::string welcomeMessage("QTM RT Interface connected");
                 if (strncmp(welcomeMessage.c_str(), mpoRTPacket->GetCommandString(), welcomeMessage.size()) == 0)
                 {
-                    // Set protocol version
-                    if (SetVersion(nMajorVersion, nMinorVersion))
+                    std::vector<RTVersion> versionList;
+                    if (bNegotiateVersion) 
                     {
-                        // Set byte order.
-                        // Unless we use protocol version 1.0, we have set the byte order by selecting the correct port.
-
-                        if ((mnMajorVersion == 1) && (mnMinorVersion == 0))
+                        versionList = RTVersion::VersionList({nMajorVersion, nMinorVersion});
+                    } 
+                    else 
+                    {
+                        versionList = std::vector<RTVersion>(1, {nMajorVersion, nMinorVersion});
+                    }
+                    
+                    for(RTVersion& version : versionList) 
+                    {
+                        // Set protocol version
+                        if (SetVersion(version.major, version.minor))
                         {
-                            if (mbBigEndian)
+                            // Set byte order.
+                            // Unless we use protocol version 1.0, we have set the byte order by selecting the correct port.
+                            if ((mnMajorVersion == 1) && (mnMinorVersion == 0))
                             {
-                                tempStr = "ByteOrder BigEndian";
+                                if (mbBigEndian)
+                                {
+                                    tempStr = "ByteOrder BigEndian";
+                                }
+                                else
+                                {
+                                    tempStr = "ByteOrder LittleEndian";
+                                }
+
+                                if (SendCommand(tempStr, responseStr))
+                                {
+                                    return true;
+                                }
+                                else
+                                {
+                                    strcpy(maErrorStr, "Set byte order failed.");
+                                }
                             }
                             else
                             {
-                                tempStr = "ByteOrder LittleEndian";
-                            }
-
-                            if (SendCommand(tempStr, responseStr))
-                            {
+                                GetState(meState, true);
                                 return true;
                             }
-                            else
-                            {
-                                strcpy(maErrorStr, "Set byte order failed.");
-                            }
-                        }
-                        else
-                        {
-                            GetState(meState, true);
-                            return true;
                         }
                     }
+
                     Disconnect();
                     return false;
                 }

--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -234,7 +234,6 @@ bool CRTProtocol::Connect(const char* pServerAddr, unsigned short nPort, unsigne
                             }
                         }
                     }
-
                     Disconnect();
                     return false;
                 }

--- a/RTProtocol.h
+++ b/RTProtocol.h
@@ -674,7 +674,7 @@ public:
     ~CRTProtocol();
 
     bool       Connect(const char* pServerAddr, unsigned short nPort = cDefaultBasePort, unsigned short* pnUDPServerPort = nullptr,
-                       int nMajorVersion = MAJOR_VERSION, int nMinorVersion = MINOR_VERSION, bool bBigEndian = false);
+                       int nMajorVersion = MAJOR_VERSION, int nMinorVersion = MINOR_VERSION, bool bBigEndian = false, bool bNegotiateVersion = true);
     unsigned short GetUdpServerPort();
     void       Disconnect();
     bool       Connected() const;

--- a/RigidBodyStreaming/RigidBodyStreaming.cpp
+++ b/RigidBodyStreaming/RigidBodyStreaming.cpp
@@ -36,10 +36,6 @@ int main(int argc, char **argv)
 
         const char           serverAddr[] = "127.0.0.1";
         const unsigned short basePort = 22222;
-        const int            majorVersion = 1;
-        const int            minorVersion = 19;
-        const bool           bigEndian = false;
-
         bool dataAvailable = false;
         bool streamFrames = false;
         unsigned short udpPort = 6734;
@@ -47,11 +43,23 @@ int main(int argc, char **argv)
         {
             if (!rtProtocol.Connected())
             {
-                if (!rtProtocol.Connect(serverAddr, basePort, &udpPort, majorVersion, minorVersion, bigEndian))
+                if (!rtProtocol.Connect(serverAddr, basePort, &udpPort))
                 {
                     printf("rtProtocol.Connect: %s\n\n", rtProtocol.GetErrorString());
-                    sleep(1);
+                    sleep(1000);
                     continue;
+                }
+
+                unsigned int major, minor;
+                if(rtProtocol.GetVersion(major, minor)) 
+                {
+                    printf("rtProtocol.Connect: RT Protocol Version %d.%d\n\n", major, minor);
+                }
+
+                std::string qtmVersion;
+                if(rtProtocol.GetQTMVersion(qtmVersion)) 
+                {
+                    printf("rtProtocol.Connect: Connected to %s\n\n", qtmVersion.data());
                 }
             }
 


### PR DESCRIPTION
# Overview
This PR changes how the ``CRTProtocol::Connect`` works, instead of directly failing when there is a version discrepancy. It continues by using ``CRTProtocol::SetVersion`` with older versions of the RTProtocol. If all of listed versions fail ``CRTProtocol::Connect`` returns false as before.

This enables us to test and use new versions of the RTProtocol before the next QTM is released, while at the same time providing working default values for new users.

Notice: This also means that if the user specifies a certain version, it might not end up as the version used. The user would have to call ``CRTProtocol::GetVersion`` to identify which version has been selected.

# Background
``Packet.h`` contains the definitions for the default RTProtocol version to be used as default values in ``CRTProtocol::Connect``.
If QTM does not support the version, or the connection is rejected, ``CRTProtocol::Connect`` will then fail by returning false.

```
#define MAJOR_VERSION           1
#define MINOR_VERSION           26
```

We change these number to signal new changes of the RTProtocol itself. That is, the communication between QTM and the Qualisys Cpp SDK. This version normally lags behind until we released the next version of QTM. The lagging behind is what we are trying to address in this PR.

# Change
- Added utility struct ``RTVersion``  which provides a rudimentary abstraction for the RTProtocol version pair.
- Added utility function ``RTVersion::VersionList`` Which takes the desired protocol version as an input, and produces a list of supported versions.
- Created a loop in ``CRTProtocol::Connect`` which, if enabled, will fall-back to older versions of the protocol if ``SetVersion`` is declined by QTM.
- Added a new arugment ``bNegotiateVersion`` (default true) to ``CRTProtocol::Connect`` which can be used to disable the fallback behaviour.

