### PR TITLE
Change 'sprintf' to 'snprintf' to Fix Compiler Warning

### DIFF
--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -696,7 +696,7 @@ bool CRTProtocol::GetCapture(const char* pFileName, bool bC3D)
                     }
                     else
                     {
-                        snprintf(maErrorStr, 1060, "No packet received. %s.", maErrorStr);
+                        snprintf(maErrorStr, CHAR_STRING_LENGTH, "No packet received. %s.", maErrorStr);
                     }
                 }
                 else

--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -696,7 +696,16 @@ bool CRTProtocol::GetCapture(const char* pFileName, bool bC3D)
                     }
                     else
                     {
-                        snprintf(maErrorStr, CHAR_STRING_LENGTH, "No packet received. %s.", maErrorStr);
+                        char tempStr[CHAR_STRING_LENGTH];
+                        maErrorStr[CHAR_STRING_LENGTH - 1] = '\0';
+                        // Calculate available space for formatting
+                        size_t maxMessageLength = CHAR_STRING_LENGTH - strlen("No packet received. ") - 1;
+                        size_t maxCopyLength = (strlen(maErrorStr) < maxMessageLength) ? strlen(maErrorStr) : maxMessageLength;
+                        // Format the message into tempStr
+                        snprintf(tempStr, CHAR_STRING_LENGTH, "No packet received. %.*s", (int)maxCopyLength, maErrorStr);
+                        // Safely copy tempStr back to maErrorStr
+                        strncpy(maErrorStr, tempStr, CHAR_STRING_LENGTH - 1);
+                        maErrorStr[CHAR_STRING_LENGTH - 1] = '\0';
                     }
                 }
                 else

--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -696,7 +696,7 @@ bool CRTProtocol::GetCapture(const char* pFileName, bool bC3D)
                     }
                     else
                     {
-                        sprintf(maErrorStr, "No packet received. %s.", maErrorStr);
+                        snprintf(maErrorStr, 1060, "No packet received. %s.", maErrorStr);
                     }
                 }
                 else

--- a/RTProtocol.h
+++ b/RTProtocol.h
@@ -15,6 +15,7 @@
 #pragma warning (disable : 4251)
 #endif
 
+#define CHAR_STRING_LENGTH 1024
 
 #ifdef EXPORT_DLL
 #define DLL_EXPORT __declspec(dllexport)
@@ -978,7 +979,7 @@ private:
     std::vector<SSettingsSkeleton> mSkeletonSettings;
     std::vector<SSettingsSkeletonHierarchical> mSkeletonSettingsHierarchical;
     SCalibration                   mCalibrationSettings;
-    char                           maErrorStr[1024];
+    char                           maErrorStr[CHAR_STRING_LENGTH];
     unsigned short                 mnBroadcastPort;
     FILE*                          mpFileBuffer;
     std::vector<SDiscoverResponse> mvsDiscoverResponseList;


### PR DESCRIPTION
# TL;DR
---

This PR fixes the compiler warning that occurs due to the following line of code:
`sprintf(maErrorStr, "No packet received. %s.", maErrorStr);`

---

# Problem

Simply adding **"No packet received. %.\*s"** to **maErrorStr** results in a warning, regardless of how large the static-array member variable is.

---

# Warning Issues

---

Initially I attempted to rectify the warning by changing to the following:
`snprintf(maErrorStr, 1060, "No packet received. %s.", maErrorStr);`
However, this resulted in the following output:
![image](https://github.com/user-attachments/assets/b57b1371-a7d8-4892-af72-62210cca7715)

---

# Building with Ubuntu Terminal

---

![image](https://github.com/user-attachments/assets/a985aaa1-87c8-49d0-8c94-5d155d8b219b)