### PR TITLE
Add Installation Paths Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(qualisys_cpp_sdk VERSION 1.0.0)
 
-include(GNUInstallDirs)
-
 option(${PROJECT_NAME}_BUILD_EXAMPLES "Build examples" OFF)
 option(${PROJECT_NAME}_BUILD_TESTS "Build tests" OFF)
 
@@ -93,16 +91,6 @@ endif()
 
 set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
 
-# 'make install' to the correct locations (provided by GNUInstallDirs)
-install(
-        TARGETS ${PROJECT_NAME}
-        EXPORT ${PROJECT_NAME}Targets
-        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" # This is for Windows
-        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}"
-)
-
 install(EXPORT ${PROJECT_NAME}Targets
         FILE ${PROJECT_NAME}Targets.cmake
         DESTINATION ${ConfigPackageLocation}
@@ -117,6 +105,16 @@ configure_package_config_file(${PROJECT_NAME}Config.cmake.in
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
         DESTINATION ${ConfigPackageLocation}
+)
+
+# 'make install' to the correct locations (provided by GNUInstallDirs)
+install(
+        TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" # This is for Windows
+        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}"
 )
 
 # Copy along headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,16 +42,16 @@ add_library(${PROJECT_NAME} ${LIB_TYPE}
 
 target_include_directories(${PROJECT_NAME} 
         PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>"
         PRIVATE
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/External/tinyxml2
+            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/External/tinyxml2"
 )
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC 
-        $<$<STREQUAL:$<PLATFORM_ID>,Windows>:ws2_32>
-        $<$<STREQUAL:$<PLATFORM_ID>,Windows>:iphlpapi>
+        "$<$<STREQUAL:$<PLATFORM_ID>,Windows>:ws2_32>"
+        "$<$<STREQUAL:$<PLATFORM_ID>,Windows>:iphlpapi>"
 )
 
 # Enable C++14
@@ -91,9 +91,17 @@ endif()
 
 # ----------- INSTALL & EXPORT -----------
 
-include(GNUInstallDirs)
-
 set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
+
+# 'make install' to the correct locations (provided by GNUInstallDirs)
+install(
+        TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" # This is for Windows
+        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}"
+)
 
 install(EXPORT ${PROJECT_NAME}Targets
         FILE ${PROJECT_NAME}Targets.cmake
@@ -109,16 +117,6 @@ configure_package_config_file(${PROJECT_NAME}Config.cmake.in
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
         DESTINATION ${ConfigPackageLocation}
-)
-
-# 'make install' to the correct locations (provided by GNUInstallDirs).
-install(
-        TARGETS ${PROJECT_NAME}
-        EXPORT ${PROJECT_NAME}Targets
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # This is for Windows
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 )
 
 # Copy along headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(qualisys_cpp_sdk VERSION 1.0.0)
 
+include(GNUInstallDirs)
+
 option(${PROJECT_NAME}_BUILD_EXAMPLES "Build examples" OFF)
 option(${PROJECT_NAME}_BUILD_TESTS "Build tests" OFF)
 
@@ -106,7 +108,7 @@ configure_package_config_file(${PROJECT_NAME}Config.cmake.in
 )
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-		DESTINATION ${ConfigPackageLocation}
+        DESTINATION ${ConfigPackageLocation}
 )
 
 # 'make install' to the correct locations (provided by GNUInstallDirs).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
+include(GNUInstallDirs)
+
 add_library(${PROJECT_NAME} ${LIB_TYPE}
         Network.cpp
         RTPacket.cpp
@@ -40,7 +42,7 @@ add_library(${PROJECT_NAME} ${LIB_TYPE}
 
 target_include_directories(${PROJECT_NAME} 
         PUBLIC
-            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
             "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>"
         PRIVATE
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/External/tinyxml2"


### PR DESCRIPTION
The author **jgoppert** originally posted the following description in [THIS PR](https://github.com/qualisys/qualisys_cpp_sdk/pull/32):

**_"GNUInstallDirs was not defined when target_include_directories was set. This caused it to be blank and the cmake target import failed. User projects importing the cmake target should use include qualisys_cpp_sdk/RTProtocol.h etc."_**

This PR implements the changes suggested by **jgoppert**.

_NOTE: It seems 'GNUInstallDirs' somehow snuck its way into master early._

---

Tests Run:
- Windows, Install to Target **"C:\qualisys_sdk_test_project"**:
![image](https://github.com/user-attachments/assets/080ce595-3118-4e54-aca0-5e1f7a77ef40)
- Ubuntu, Install to **'.'**
![image](https://github.com/user-attachments/assets/6062ac1b-d647-4265-8c4b-14a289048c71)