### PR TITLE
[Feature Branch] - CMarkup --> Tinyxml2 : SetCameraLensControlSettings()

### DIFF
--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -2751,7 +2751,7 @@ bool CRTProtocol::SetCameraSyncOutSettings(
   // nCameraID starts on 1. If nCameraID < 0 then settings are applied to all cameras.
 bool CRTProtocol::SetCameraLensControlSettings(const unsigned int nCameraID, const float focus, const float aperture)
 {
-    auto serializer = CMarkupSerializer(mnMajorVersion, mnMinorVersion);
+    CTinyxml2Serializer serializer(mnMajorVersion, mnMinorVersion);
     auto message = serializer.SetCameraLensControlSettings(nCameraID, focus, aperture);
     return SendXML(message.data());
 

--- a/Tinyxml2Serializer.cpp
+++ b/Tinyxml2Serializer.cpp
@@ -3431,10 +3431,8 @@ std::string CTinyxml2Serializer::SetCameraLensControlSettings(const unsigned int
     AddXMLElementFloatWithTextAttribute(*pLensControl, "Focus", &pFocus, 6, oXML, "Value");
     AddXMLElementFloatWithTextAttribute(*pLensControl, "Aperture", &pAperture, 6, oXML, "Value");
 
-    // Convert document to string
     tinyxml2::XMLPrinter printer;
     oXML.Print(&printer);
-
     return printer.CStr();
 }
 

--- a/Tinyxml2Serializer.cpp
+++ b/Tinyxml2Serializer.cpp
@@ -66,17 +66,14 @@ void CTinyxml2Serializer::AddXMLElementFloat(tinyxml2::XMLElement& parent, const
     parent.InsertEndChild(elem);
 }
 
-void CTinyxml2Serializer::AddXMLElementFloatWithTextAttribute(tinyxml2::XMLElement& parent, const char* tTag, const float* pfValue, unsigned int pnDecimals, tinyxml2::XMLDocument& oXML, const char* tTextAttr)
+void CTinyxml2Serializer::AddXMLElementFloatWithTextAttribute(tinyxml2::XMLDocument& oXML, tinyxml2::XMLElement& parent, const char* elementName, const char* attributeName, const float& value, unsigned int decimals)
 {
-    if (pfValue)
-    {
-        char formattedValue[32];
-        snprintf(formattedValue, sizeof(formattedValue), "%.*f", pnDecimals, *pfValue);
+    char formattedValue[32];
+    snprintf(formattedValue, sizeof(formattedValue), "%.*f", decimals, value);
 
-        tinyxml2::XMLElement* elem = oXML.NewElement(tTag);
-        elem->SetAttribute(tTextAttr, formattedValue);
-        parent.InsertEndChild(elem);
-    }
+    tinyxml2::XMLElement* elem = oXML.NewElement(elementName);
+    elem->SetAttribute(attributeName, formattedValue);
+    parent.InsertEndChild(elem);
 }
 
 
@@ -3428,8 +3425,8 @@ std::string CTinyxml2Serializer::SetCameraLensControlSettings(const unsigned int
     pCamera->InsertEndChild(pLensControl);
 
     // Add Focus and Aperture as float attributes
-    AddXMLElementFloatWithTextAttribute(*pLensControl, "Focus", &pFocus, 6, oXML, "Value");
-    AddXMLElementFloatWithTextAttribute(*pLensControl, "Aperture", &pAperture, 6, oXML, "Value");
+    AddXMLElementFloatWithTextAttribute(oXML, *pLensControl, "Focus", "Value", pFocus, 6);
+    AddXMLElementFloatWithTextAttribute(oXML, *pLensControl, "Aperture", "Value", pAperture, 6);
 
     tinyxml2::XMLPrinter printer;
     oXML.Print(&printer);

--- a/Tinyxml2Serializer.cpp
+++ b/Tinyxml2Serializer.cpp
@@ -66,6 +66,20 @@ void CTinyxml2Serializer::AddXMLElementFloat(tinyxml2::XMLElement& parent, const
     parent.InsertEndChild(elem);
 }
 
+void CTinyxml2Serializer::AddXMLElementFloatWithTextAttribute(tinyxml2::XMLElement& parent, const char* tTag, const float* pfValue, unsigned int pnDecimals, tinyxml2::XMLDocument& oXML, const char* tTextAttr)
+{
+    if (pfValue)
+    {
+        char formattedValue[32];
+        snprintf(formattedValue, sizeof(formattedValue), "%.*f", pnDecimals, *pfValue);
+
+        tinyxml2::XMLElement* elem = oXML.NewElement(tTag);
+        elem->SetAttribute(tTextAttr, formattedValue);
+        parent.InsertEndChild(elem);
+    }
+}
+
+
 void CTinyxml2Serializer::AddXMLElementTransform(tinyxml2::XMLDocument& oXML, tinyxml2::XMLElement& parentElem, const std::string& name, const SPosition& position, const SRotation& rotation)
 {
     tinyxml2::XMLElement* transformElem = oXML.NewElement(name.c_str());
@@ -3392,34 +3406,36 @@ std::string CTinyxml2Serializer::SetCameraSyncOutSettings(const unsigned int pCa
 std::string CTinyxml2Serializer::SetCameraLensControlSettings(const unsigned int pCameraId, const float pFocus,
     const float pAperture)
 {
-    //CTinyxml2 oXML;
+    tinyxml2::XMLDocument oXML;
 
-    //oXML.AddElem("QTM_Settings");
-    //oXML.IntoElem();
-    //oXML.AddElem("General");
-    //oXML.IntoElem();
+    // Root element
+    tinyxml2::XMLElement* pRoot = oXML.NewElement("QTM_Settings");
+    oXML.InsertFirstChild(pRoot);
 
-    //oXML.AddElem("Camera");
-    //oXML.IntoElem();
+    // General element
+    tinyxml2::XMLElement* pGeneral = oXML.NewElement("General");
+    pRoot->InsertEndChild(pGeneral);
 
-    //AddXMLElementUnsignedInt(&oXML, "ID", &pCameraId);
+    // Camera element
+    tinyxml2::XMLElement* pCamera = oXML.NewElement("Camera");
+    pGeneral->InsertEndChild(pCamera);
 
-    //oXML.AddElem("LensControl");
-    //oXML.IntoElem();
+    // Add Camera ID
+    AddXMLElementUnsignedInt(*pCamera, "ID", &pCameraId, oXML);
 
-    //oXML.AddElem("Focus");
-    //oXML.AddAttrib("Value", CTinyxml2::Format("%f", pFocus).c_str());
-    //oXML.AddElem("Aperture");
-    //oXML.AddAttrib("Value", CTinyxml2::Format("%f", pAperture).c_str());
+    // LensControl element
+    tinyxml2::XMLElement* pLensControl = oXML.NewElement("LensControl");
+    pCamera->InsertEndChild(pLensControl);
 
-    //oXML.OutOfElem(); // LensControl
-    //oXML.OutOfElem(); // Camera
-    //oXML.OutOfElem(); // General
-    //oXML.OutOfElem(); // QTM_Settings
+    // Add Focus and Aperture as float attributes
+    AddXMLElementFloatWithTextAttribute(*pLensControl, "Focus", &pFocus, 6, oXML, "Value");
+    AddXMLElementFloatWithTextAttribute(*pLensControl, "Aperture", &pAperture, 6, oXML, "Value");
 
-    //return oXML.GetDoc();
+    // Convert document to string
+    tinyxml2::XMLPrinter printer;
+    oXML.Print(&printer);
 
-    return "";
+    return printer.CStr();
 }
 
 std::string CTinyxml2Serializer::SetCameraAutoExposureSettings(const unsigned int pCameraId, const bool pAutoExposure,

--- a/Tinyxml2Serializer.h
+++ b/Tinyxml2Serializer.h
@@ -94,7 +94,7 @@ namespace qualisys_cpp_sdk {
         void AddXMLElementUnsignedInt(tinyxml2::XMLElement& parent, const char* tTag, const unsigned int nValue, tinyxml2::XMLDocument& oXML);
         void AddXMLElementUnsignedInt(tinyxml2::XMLElement& parent, const char* tTag, const unsigned int* pnValue, tinyxml2::XMLDocument& oXML);
         void AddXMLElementFloat(tinyxml2::XMLElement& parent, const char* tTag, const float* pfValue, unsigned int pnDecimals, tinyxml2::XMLDocument& oXML);
-        void AddXMLElementFloatWithTextAttribute(tinyxml2::XMLElement& parent, const char* tTag, const float* pfValue, unsigned int pnDecimals, tinyxml2::XMLDocument& oXML, const char* tTextAttr);
+        void AddXMLElementFloatWithTextAttribute(tinyxml2::XMLDocument& oXML, tinyxml2::XMLElement& parent, const char* elementName, const char* attributeName, const float& value, unsigned int decimals);
         void AddXMLElementTransform(tinyxml2::XMLDocument& oXML, tinyxml2::XMLElement& parentElem, const std::string& name, const SPosition& position, const SRotation& rotation);
         void AddXMLElementDOF(tinyxml2::XMLDocument& oXML, tinyxml2::XMLElement& parentElem, const std::string& name, const SDegreeOfFreedom& degreeOfFreedoms);
     };

--- a/Tinyxml2Serializer.h
+++ b/Tinyxml2Serializer.h
@@ -94,6 +94,7 @@ namespace qualisys_cpp_sdk {
         void AddXMLElementUnsignedInt(tinyxml2::XMLElement& parent, const char* tTag, const unsigned int nValue, tinyxml2::XMLDocument& oXML);
         void AddXMLElementUnsignedInt(tinyxml2::XMLElement& parent, const char* tTag, const unsigned int* pnValue, tinyxml2::XMLDocument& oXML);
         void AddXMLElementFloat(tinyxml2::XMLElement& parent, const char* tTag, const float* pfValue, unsigned int pnDecimals, tinyxml2::XMLDocument& oXML);
+        void AddXMLElementFloatWithTextAttribute(tinyxml2::XMLElement& parent, const char* tTag, const float* pfValue, unsigned int pnDecimals, tinyxml2::XMLDocument& oXML, const char* tTextAttr);
         void AddXMLElementTransform(tinyxml2::XMLDocument& oXML, tinyxml2::XMLElement& parentElem, const std::string& name, const SPosition& position, const SRotation& rotation);
         void AddXMLElementDOF(tinyxml2::XMLDocument& oXML, tinyxml2::XMLElement& parentElem, const std::string& name, const SDegreeOfFreedom& degreeOfFreedoms);
     };


### PR DESCRIPTION
This PR replaces CMarkup with Tinyxml2 in the SetCameraLensControlSettings() function. This branch also adds the following:
- AddXMLElementFloatWithTextAttribute

![image](https://github.com/user-attachments/assets/0c7b2463-c97e-4d6e-9e6d-55d0aafc89a5)