### PR TITLE
RTClientExample: Fixed incorrect output parameter

### DIFF
--- a/RTClientExample/Input.cpp
+++ b/RTClientExample/Input.cpp
@@ -649,7 +649,7 @@ void CInput::ReadExtTimeBaseSettings(bool         &bEnabled,            int     
             bNegativeEdge = ReadYesNo("Negative Edge (y/n)? ", true);
         }
 
-        nFrequencyTolerance = ReadInt("Enter Signal Shutter Delay (us) : ", 0);
+        nSignalShutterDelay = ReadInt("Enter Signal Shutter Delay (us) : ", 0);
 
         if ((nSignalSource == 0 || nSignalSource == 1 || nSignalSource == 3) && !bSignalModePeriodic)
         {


### PR DESCRIPTION
Fixes issues where __frequency tolerance__ is incorrectly set where __signal shutter delay__ should be configured.