### PR TITLE
Fix build errors

### DIFF
--- a/MarkupSerializer.cpp
+++ b/MarkupSerializer.cpp
@@ -1,7 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 
 #include "MarkupSerializer.h"
-
+#include <cstring>
 #include <algorithm>
 #include <map>
 
@@ -2833,7 +2833,7 @@ bool CMarkupDeserializer::DeserializeSkeletonSettings(bool pSkeletonGlobalData, 
     return true;
 } // ReadSkeletonSettings
 
-namespace 
+namespace
 {
     bool ReadXmlFov(std::string name, CMarkup& oXML, SCalibrationFov& fov)
     {
@@ -3188,7 +3188,7 @@ std::string CMarkupSerializer::SetExtTimeBaseSettings(const bool* pbEnabled, con
     AddXMLElementUnsignedInt(&oXML, "Signal_Shutter_Delay", pnSignalShutterDelay);
     AddXMLElementFloat(&oXML, "Non_Periodic_Timeout", pfNonPeriodicTimeout, 3);
 
-    oXML.OutOfElem(); // External_Time_Base            
+    oXML.OutOfElem(); // External_Time_Base
     oXML.OutOfElem(); // General
     oXML.OutOfElem(); // QTM_Settings
 
@@ -3383,7 +3383,7 @@ std::string CMarkupSerializer::SetCameraSyncOutSettings(const unsigned int pCame
                 oXML.AddElem("Mode", "System live time");
                 break;
             default:
-                return false; // Should never happen
+                return std::string(); // Should never happen
             }
 
             if (*peSyncOutMode == ModeMultiplier ||

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1,4 +1,5 @@
 #include "Settings.h"
+#include "algorithm"
 
 const char* qualisys_cpp_sdk::SkeletonDofToStringSettings(EDegreeOfFreedom dof)
 {


### PR DESCRIPTION
The SDK stopped building with the recent commits. By looking at the recent commits and pull request I understand that there is some refactoring underway. But I thought I'd fix the build errors.


```bash
$ mkdir build
$ cd build
$ cmake ..
```
`cmake.log`
```txt
-- Configuring done
-- Generating done
-- Build files have been written to: build
```
```bash
make -j10
```
```txt
Consolidate compiler generated dependencies of target qualisys_cpp_sdk
[ 28%] Building CXX object CMakeFiles/qualisys_cpp_sdk.dir/MarkupSerializer.cpp.o
[ 28%] Building CXX object CMakeFiles/qualisys_cpp_sdk.dir/Settings.cpp.o
Settings.cpp: In function ‘const char* qualisys_cpp_sdk::SkeletonDofToStringSettings(qualisys_cpp_sdk::EDegreeOfFreedom)’:
Settings.cpp:5:20: error: ‘find_if’ is not a member of ‘std’
    5 |     auto it = std::find_if(DEGREES_OF_FREEDOM.begin(), DEGREES_OF_FREEDOM.end(), [&](const auto& DEGREE_OF_FREEDOM) { return (DEGREE_OF_FREEDOM.first == dof); });
      |                    ^~~~~~~
Settings.cpp: In function ‘qualisys_cpp_sdk::EDegreeOfFreedom qualisys_cpp_sdk::SkeletonStringToDofSettings(const string&)’:
Settings.cpp:17:20: error: ‘find_if’ is not a member of ‘std’
   17 |     auto it = std::find_if(DEGREES_OF_FREEDOM.begin(), DEGREES_OF_FREEDOM.end(), [&](const auto& DEGREE_OF_FREEDOM) { return (DEGREE_OF_FREEDOM.second == str); });
      |                    ^~~~~~~
make[2]: *** [CMakeFiles/qualisys_cpp_sdk.dir/

build.make:132: CMakeFiles/qualisys_cpp_sdk.dir/Settings.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
MarkupSerializer.cpp: In member function ‘virtual bool qualisys_cpp_sdk::CMarkupDeserializer::Deserialize3DSettings(qualisys_cpp_sdk::SSettings3D&, bool&)’:
MarkupSerializer.cpp:1478:5: error: ‘strcpy’ was not declared in this scope
 1478 |     strcpy(p3dSettings.pCalibrationTime, tStr.c_str());
      |     ^~~~~~
MarkupSerializer.cpp:7:1: note: ‘strcpy’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
    6 | #include <map>
  +++ |+#include <cstring>
    7 |
MarkupSerializer.cpp: In member function ‘virtual std::string qualisys_cpp_sdk::CMarkupSerializer::SetCameraSyncOutSettings(unsigned int, unsigned int, const qualisys_cpp_sdk::ESyncOutFreqMode*, const unsigned int*, const float*, const bool*)’:
MarkupSerializer.cpp:3386:24: error: could not convert ‘false’ from ‘bool’ to ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
 3386 |                 return false; // Should never happen
      |                        ^~~~~
      |                        |
      |                        bool
make[2]: *** [CMakeFiles/qualisys_cpp_sdk.dir/build.make:146: CMakeFiles/qualisys_cpp_sdk.dir/MarkupSerializer.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/qualisys_cpp_sdk.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```
[make.log](https://github.com/user-attachments/files/18755198/make.log)
[cmake.log](https://github.com/user-attachments/files/18755200/cmake.log)