### PR TITLE
Change Optional Parameters from References to Pointers

### DIFF
--- a/RTClientExample/Input.cpp
+++ b/RTClientExample/Input.cpp
@@ -254,7 +254,7 @@ bool CInput::ReadDataComponents(unsigned int &nComponentType, char* selectedAnal
         if (!ReadYesNo("Read all channels (y/n)\n", true))
         {
             printf("Select analog channels: (Ex, 1,3,4-7,8)\n");
-            fgets(*selectedAnalogChannels, *selectedAnalogChannelsLen, stdin);
+            fgets(selectedAnalogChannels, selectedAnalogChannelsLen, stdin);
         }
     }
 
@@ -723,7 +723,7 @@ void CInput::ReadCameraSettings(unsigned int& nCameraId,           int&   nMode,
     int tmpVideoRes = ReadChar('1', true) - '0' - 1;
     if (tmpVideoRes >= 0 && tmpVideoRes <= 4)
     {
-        videoResolution = new CRTProtocol::EVideoResolution(tmpVideoRes);
+        videoResolution = new CRTProtocol::EVideoResolution(static_cast<CRTProtocol::EVideoResolution>(tmpVideoRes));
     }
 
     printf("Enter Video AspectRatio :\n");
@@ -735,7 +735,7 @@ void CInput::ReadCameraSettings(unsigned int& nCameraId,           int&   nMode,
     int tmpVideoAsp = ReadChar('1', true) - '0' - 1;
     if (tmpVideoAsp >= 0 && tmpVideoAsp <= 2)
     {
-        videoAspectRatio = new CRTProtocol::EVideoAspectRatio(tmpVideoAsp);
+        videoAspectRatio = new CRTProtocol::EVideoAspectRatio(static_cast<CRTProtocol::EVideoAspectRatio>(tmpVideoAsp));
     }
 
     nRotation = ReadInt("Enter Camera Rotation (degrees) (Default 0 degrees): ", 0);

--- a/RTClientExample/Input.cpp
+++ b/RTClientExample/Input.cpp
@@ -483,7 +483,7 @@ bool CInput::ReadDataTest(bool bLogSelection, bool &bStreamTCP, bool &bStreamUDP
     return false;
 }
 
-void CInput::ReadGeneralSettings(unsigned int &nCaptureFrequency, float &fCaptureTime, bool* bExternalTrigger, bool* trigNO, bool* trigNC, bool* trigSoftware)
+void CInput::ReadGeneralSettings(unsigned int &nCaptureFrequency, float &fCaptureTime, bool*& bExternalTrigger, bool*& trigNO, bool*& trigNC, bool*& trigSoftware)
 {
     nCaptureFrequency = ReadInt("Enter Capture Frequency (Hz) : ", 20);
 
@@ -605,11 +605,11 @@ void CInput::ReadProcessingActionsSettings(CRTProtocol::EProcessingActions &ePro
     }
 }
 
-void CInput::ReadExtTimeBaseSettings(bool          &bEnabled,           int*          nSignalSource,
-                                     bool*         bSignalModePeriodic, unsigned int* nMultiplier,
-                                     unsigned int* nDivisor,            unsigned int* nFrequencyTolerance,
-                                     float*        fNominalFrequency,   bool*         bNegativeEdge,
-                                     unsigned int* nSignalShutterDelay, float*        fNonPeriodicTimeout)
+void CInput::ReadExtTimeBaseSettings(bool          &bEnabled,           int*&          nSignalSource,
+                                     bool*&         bSignalModePeriodic, unsigned int*& nMultiplier,
+                                     unsigned int*& nDivisor,            unsigned int*& nFrequencyTolerance,
+                                     float*&        fNominalFrequency,   bool*&         bNegativeEdge,
+                                     unsigned int*& nSignalShutterDelay, float*&        fNonPeriodicTimeout)
 {
     bEnabled = ReadYesNo("Enable External Time Base (y/n)? ", false);
 
@@ -633,7 +633,7 @@ void CInput::ReadExtTimeBaseSettings(bool          &bEnabled,           int*    
             bSignalModePeriodic = ReadNewYesNo("Signal Mode Periodic (y/n)? ", true);
         }
 
-        if ((*nSignalSource == 0 || *nSignalSource == 1 || *nSignalSource == 2 || *nSignalSource == 3) && *bSignalModePeriodic)
+        if ((*nSignalSource == 0 || *nSignalSource == 1 || *nSignalSource == 2 || *nSignalSource == 3) && bSignalModePeriodic)
         {
             nMultiplier = ReadNewUnsignedInt("Enter Frequency Multiplier : ", 1);
 
@@ -681,11 +681,11 @@ void CInput::ReadTimestampSettings(CRTProtocol::SSettingsGeneralExternalTimestam
     }
 }
 
-void CInput::ReadCameraSettings(unsigned int& nCameraId,           int&   nMode,            CRTProtocol::EVideoResolution* videoResolution, CRTProtocol::EVideoAspectRatio* videoAspectRatio,
-                                unsigned int* nVideoFrequency,     float* fVideoExposure,   float* fVideoFlashTime,
-                                float*        fMarkerExposure,     float* fMarkerThreshold, int&   nRotation,
+void CInput::ReadCameraSettings(unsigned int& nCameraId,           int&   nMode,            CRTProtocol::EVideoResolution*& videoResolution, CRTProtocol::EVideoAspectRatio*& videoAspectRatio,
+                                unsigned int*& nVideoFrequency,     float*& fVideoExposure,   float*& fVideoFlashTime,
+                                float*&        fMarkerExposure,     float*& fMarkerThreshold, int&   nRotation,
                                 float&        fFocus,              float& fAperture,        bool&  autoExposure,
-                                float*        exposureCompensation, bool& autoWhiteBalance)
+                                float&        exposureCompensation, bool& autoWhiteBalance)
 {
     nCameraId = ReadInt("\nEnter Camera ID : ", 1);
 
@@ -751,19 +751,23 @@ void CInput::ReadCameraSettings(unsigned int& nCameraId,           int&   nMode,
     autoExposure = ReadYesNo("Enable Auto Exposure? (y/n): ", false);
     if (autoExposure)
     {
-        exposureCompensation = ReadNewFloat("Enter Exposure Compensation: ", 0);
+        exposureCompensation = ReadFloat("Enter Exposure Compensation: ", 0);
+    }
+    else
+    {
+        exposureCompensation = 0.0f;
     }
     autoWhiteBalance = ReadYesNo("Enable Auto White Balance? (y/n): ", true);
 }
 
 
-void CInput::ReadCameraSyncOutSettings(unsigned int& nCameraId, int& portNumber, int* nSyncOutMode, unsigned int* nSyncOutValue,
-                                    float* fSyncOutDutyCycle, bool* bSyncOutNegativePolarity)
+void CInput::ReadCameraSyncOutSettings(unsigned int& nCameraId, int& portNumber, int*& nSyncOutMode, unsigned int*& nSyncOutValue,
+                                    float*& fSyncOutDutyCycle, bool*& bSyncOutNegativePolarity)
 {
     nCameraId = ReadInt("\nEnter Camera ID : ", 1);
-    portNumber = ReadInt("Enter Sync out port number (1-3) ", 1);
+    portNumber = ReadInt("Enter Sync out port number (1-3) : ", 1);
 
-    if (portNumber > 0 && portNumber < 3)
+    if (portNumber == 1 || portNumber == 2)
     {
         printf("Enter Camera Mode :\n");
         printf("  1 : Shutter Out\n");
@@ -774,7 +778,8 @@ void CInput::ReadCameraSyncOutSettings(unsigned int& nCameraId, int& portNumber,
         printf("  6 : Fixed 100 Hz\n");
         printf("  7 : System Live Time\n");
         printf("Select 1 - 7 : ");
-        nSyncOutMode = ReadNewCharAsInt('1', true) - '0';
+        nSyncOutMode = ReadNewCharAsInt('1', true);
+        *nSyncOutMode -= static_cast<int>('0');
         if (*nSyncOutMode < 1 || *nSyncOutMode > 7)
         {
             *nSyncOutMode = 1;
@@ -787,9 +792,13 @@ void CInput::ReadCameraSyncOutSettings(unsigned int& nCameraId, int& portNumber,
 
             fSyncOutDutyCycle = ReadNewFloat("Enter Sync Out Duty Cycle (%%) : ", 0.5);
         }
-    }
 
-    if (*nSyncOutMode < 6)
+        if (*nSyncOutMode < 6)
+        {
+            bSyncOutNegativePolarity = ReadNewYesNo("Negative Polarity? (y/n): ", true);
+        }
+    }
+    else if (portNumber == 3)
     {
         bSyncOutNegativePolarity = ReadNewYesNo("Negative Polarity? (y/n): ", true);
     }

--- a/RTClientExample/Input.cpp
+++ b/RTClientExample/Input.cpp
@@ -171,8 +171,9 @@ bool CInput::ReadOperation(EOperation &eOperation)
 }
 
 
-bool CInput::ReadStreamRate(CRTProtocol::EStreamRate &eRate, int &nArg)
+bool CInput::ReadStreamRate(CRTProtocol::EStreamRate &eRate, int& nArg)
 {
+    nArg = 0;
     int nSelection;
 
     printf("\nSelect Transfer Rate:\n\n");
@@ -253,7 +254,7 @@ bool CInput::ReadDataComponents(unsigned int &nComponentType, char* selectedAnal
         if (!ReadYesNo("Read all channels (y/n)\n", true))
         {
             printf("Select analog channels: (Ex, 1,3,4-7,8)\n");
-            fgets(selectedAnalogChannels, selectedAnalogChannelsLen, stdin);
+            fgets(*selectedAnalogChannels, *selectedAnalogChannelsLen, stdin);
         }
     }
 
@@ -261,7 +262,7 @@ bool CInput::ReadDataComponents(unsigned int &nComponentType, char* selectedAnal
 } // ReadDataComponent
 
 
-unsigned int CInput::ReadDataComponent(bool printInstr, bool &skeletonGlobalReferenceFrame)
+unsigned int CInput::ReadDataComponent(bool printInstr, bool& skeletonGlobalReferenceFrame)
 {
     if (printInstr)
     {
@@ -396,7 +397,7 @@ bool CInput::Read2DNoiseTest()
 
 
 bool CInput::ReadDataTest(bool bLogSelection, bool &bStreamTCP, bool &bStreamUDP, bool &bLogToFile,
-                          bool &bOnlyTimeAndFrameNumber, unsigned short &nUDPPort, char *tUDPAddress, int nAddressLen)
+                          bool &bOnlyTimeAndFrameNumber, unsigned short& nUDPPort, char *tUDPAddress, int nAddressLen)
 {
     int nSelection;
 
@@ -405,6 +406,7 @@ bool CInput::ReadDataTest(bool bLogSelection, bool &bStreamTCP, bool &bStreamUDP
     bLogToFile              = false;
     bOnlyTimeAndFrameNumber = false;
     tUDPAddress[0]          = 0;
+    nUDPPort                = 0;
 
     printf("\nSelect Transfer Mode:\n\n"
         "1 : Stream Data TCP (Default).\n"
@@ -481,7 +483,7 @@ bool CInput::ReadDataTest(bool bLogSelection, bool &bStreamTCP, bool &bStreamUDP
     return false;
 }
 
-void CInput::ReadGeneralSettings(unsigned int &nCaptureFrequency, float &fCaptureTime, bool &bExternalTrigger, bool& trigNO, bool& trigNC, bool& trigSoftware)
+void CInput::ReadGeneralSettings(unsigned int &nCaptureFrequency, float &fCaptureTime, bool* bExternalTrigger, bool* trigNO, bool* trigNC, bool* trigSoftware)
 {
     nCaptureFrequency = ReadInt("Enter Capture Frequency (Hz) : ", 20);
 
@@ -489,13 +491,13 @@ void CInput::ReadGeneralSettings(unsigned int &nCaptureFrequency, float &fCaptur
     
     if (mnMajorVersion > 1 || mnMinorVersion > 14)
     {
-        trigNO = ReadYesNo("Enter Start on Trig NO (y/n)?\n", false);
-        trigNC = ReadYesNo("Enter Start Trig NC (y/n)?\n", false);
-        trigSoftware = ReadYesNo("Enter Start Software trigger (y/n)?\n", false);
+        trigNO = ReadNewYesNo("Enter Start on Trig NO (y/n)?\n", false);
+        trigNC = ReadNewYesNo("Enter Start Trig NC (y/n)?\n", false);
+        trigSoftware = ReadNewYesNo("Enter Start Software trigger (y/n)?\n", false);
     }
     else
     {
-        bExternalTrigger = ReadYesNo("Enter Start on External Trigger (y/n)?\n", false);
+        bExternalTrigger = ReadNewYesNo("Enter Start on External Trigger (y/n)?\n", false);
     }
 
 }
@@ -603,11 +605,11 @@ void CInput::ReadProcessingActionsSettings(CRTProtocol::EProcessingActions &ePro
     }
 }
 
-void CInput::ReadExtTimeBaseSettings(bool         &bEnabled,            int          &nSignalSource,
-                                     bool         &bSignalModePeriodic, unsigned int &nMultiplier,
-                                     unsigned int &nDivisor,            unsigned int &nFrequencyTolerance,
-                                     float        &fNominalFrequency,   bool         &bNegativeEdge,
-                                     unsigned int &nSignalShutterDelay, float        &fNonPeriodicTimeout)
+void CInput::ReadExtTimeBaseSettings(bool          &bEnabled,           int*          nSignalSource,
+                                     bool*         bSignalModePeriodic, unsigned int* nMultiplier,
+                                     unsigned int* nDivisor,            unsigned int* nFrequencyTolerance,
+                                     float*        fNominalFrequency,   bool*         bNegativeEdge,
+                                     unsigned int* nSignalShutterDelay, float*        fNonPeriodicTimeout)
 {
     bEnabled = ReadYesNo("Enable External Time Base (y/n)? ", false);
 
@@ -619,41 +621,42 @@ void CInput::ReadExtTimeBaseSettings(bool         &bEnabled,            int     
         printf("  3 : SMPTE\n");
         printf("  4 : Video Sync\n");
         printf("Select 1 - 4 : ");
-        nSignalSource = ReadChar('1', true) - '0' - 1;
-        if (nSignalSource < 0 || nSignalSource > 3)
+        nSignalSource = ReadNewCharAsInt('1', true);
+        *nSignalSource = *nSignalSource - '0' - 1;
+        if (*nSignalSource < 0 || *nSignalSource > 3)
         {
-            nSignalSource = 0;
+            *nSignalSource = 0;
         }
 
-        if (nSignalSource == 0 || nSignalSource == 1 || nSignalSource == 3)
+        if (*nSignalSource == 0 || *nSignalSource == 1 || *nSignalSource == 3)
         {
-            bSignalModePeriodic = ReadYesNo("Signal Mode Periodic (y/n)? ", true);
+            bSignalModePeriodic = ReadNewYesNo("Signal Mode Periodic (y/n)? ", true);
         }
 
-        if ((nSignalSource == 0 || nSignalSource == 1 || nSignalSource == 2 || nSignalSource == 3) && bSignalModePeriodic)
+        if ((*nSignalSource == 0 || *nSignalSource == 1 || *nSignalSource == 2 || *nSignalSource == 3) && *bSignalModePeriodic)
         {
-            nMultiplier = ReadInt("Enter Frequency Multiplier : ", 1);
+            nMultiplier = ReadNewUnsignedInt("Enter Frequency Multiplier : ", 1);
 
-            nDivisor = ReadInt("Enter Frequency Divisor : ", 1);
+            nDivisor = ReadNewUnsignedInt("Enter Frequency Divisor : ", 1);
 
-            if (nSignalSource == 0 || nSignalSource == 1 || nSignalSource == 3)
+            if (*nSignalSource == 0 || *nSignalSource == 1 || *nSignalSource == 3)
             {
-                nFrequencyTolerance = ReadInt("Enter Frequency Tolerance (ppm): ", 1000);
+                nFrequencyTolerance = ReadNewUnsignedInt("Enter Frequency Tolerance (ppm): ", 1000);
             }
 
-            fNominalFrequency = ReadFloat("Enter Nominal Frequency (Hz) : ", 0);
+            fNominalFrequency = ReadNewFloat("Enter Nominal Frequency (Hz) : ", 0);
         }
 
-        if (nSignalSource == 0 || nSignalSource == 3)
+        if (*nSignalSource == 0 || *nSignalSource == 3)
         {
-            bNegativeEdge = ReadYesNo("Negative Edge (y/n)? ", true);
+            bNegativeEdge = ReadNewYesNo("Negative Edge (y/n)? ", true);
         }
 
-        nSignalShutterDelay = ReadInt("Enter Signal Shutter Delay (us) : ", 0);
+        nSignalShutterDelay = ReadNewUnsignedInt("Enter Signal Shutter Delay (us) : ", 0);
 
-        if ((nSignalSource == 0 || nSignalSource == 1 || nSignalSource == 3) && !bSignalModePeriodic)
+        if ((*nSignalSource == 0 || *nSignalSource == 1 || *nSignalSource == 3) && !bSignalModePeriodic)
         {
-            fNonPeriodicTimeout = ReadFloat("Non Periodic Timeout (s) : ", 1);
+            fNonPeriodicTimeout = ReadNewFloat("Non Periodic Timeout (s) : ", 1);
         }
     }
 }
@@ -678,11 +681,11 @@ void CInput::ReadTimestampSettings(CRTProtocol::SSettingsGeneralExternalTimestam
     }
 }
 
-void CInput::ReadCameraSettings(unsigned int &nCameraId,        int   &nMode,            CRTProtocol::EVideoResolution &videoResolution, CRTProtocol::EVideoAspectRatio &videoAspectRatio,
-                                unsigned int &nVideoFrequency,  float &fVideoExposure,   float &fVideoFlashTime,
-                                float        &fMarkerExposure,  float &fMarkerThreshold, int   &nRotation,
-                                float        &fFocus,           float &fAperture,        bool  &autoExposure,
-                                float        &exposureCompensation, bool &autoWhiteBalance)
+void CInput::ReadCameraSettings(unsigned int& nCameraId,           int&   nMode,            CRTProtocol::EVideoResolution* videoResolution, CRTProtocol::EVideoAspectRatio* videoAspectRatio,
+                                unsigned int* nVideoFrequency,     float* fVideoExposure,   float* fVideoFlashTime,
+                                float*        fMarkerExposure,     float* fMarkerThreshold, int&   nRotation,
+                                float&        fFocus,              float& fAperture,        bool&  autoExposure,
+                                float*        exposureCompensation, bool& autoWhiteBalance)
 {
     nCameraId = ReadInt("\nEnter Camera ID : ", 1);
 
@@ -699,14 +702,14 @@ void CInput::ReadCameraSettings(unsigned int &nCameraId,        int   &nMode,   
 
     if (nMode == 0 || nMode == 1)
     {
-        fMarkerExposure = ReadFloat("Enter Marker Exposure (us) (Default 300 us): ", 300);
-        fMarkerThreshold = ReadFloat("Enter Marker Threshold (50 - 900) (Default 150) : ", 150);
+        fMarkerExposure = ReadNewFloat("Enter Marker Exposure (us) (Default 300 us): ", 300);
+        fMarkerThreshold = ReadNewFloat("Enter Marker Threshold (50 - 900) (Default 150) : ", 150);
     }
     if (nMode == 2)
     {
-        nVideoFrequency = ReadInt("Enter Video Frequency (Default 24 Hz) : ", 24);
-        fVideoExposure = ReadFloat("Enter Video Exposure (us) (Default 300 us) : ", 300);
-        fVideoFlashTime = ReadFloat("Enter Video Flash Time (us) (Default 300 us) : ", 300);
+        nVideoFrequency = ReadNewUnsignedInt("Enter Video Frequency (Default 24 Hz) : ", 24);
+        fVideoExposure = ReadNewFloat("Enter Video Exposure (us) (Default 300 us) : ", 300);
+        fVideoFlashTime = ReadNewFloat("Enter Video Flash Time (us) (Default 300 us) : ", 300);
     }
 
     printf("Enter Video Resolution :\n");
@@ -720,11 +723,7 @@ void CInput::ReadCameraSettings(unsigned int &nCameraId,        int   &nMode,   
     int tmpVideoRes = ReadChar('1', true) - '0' - 1;
     if (tmpVideoRes >= 0 && tmpVideoRes <= 4)
     {
-        videoResolution = (CRTProtocol::EVideoResolution)tmpVideoRes;
-    }
-    else
-    {
-        videoResolution = CRTProtocol::VideoResolutionNone;
+        videoResolution = new CRTProtocol::EVideoResolution(tmpVideoRes);
     }
 
     printf("Enter Video AspectRatio :\n");
@@ -736,11 +735,7 @@ void CInput::ReadCameraSettings(unsigned int &nCameraId,        int   &nMode,   
     int tmpVideoAsp = ReadChar('1', true) - '0' - 1;
     if (tmpVideoAsp >= 0 && tmpVideoAsp <= 2)
     {
-        videoAspectRatio = (CRTProtocol::EVideoAspectRatio)tmpVideoAsp;;
-    }
-    else
-    {
-        videoAspectRatio = CRTProtocol::VideoAspectRatioNone;
+        videoAspectRatio = new CRTProtocol::EVideoAspectRatio(tmpVideoAsp);
     }
 
     nRotation = ReadInt("Enter Camera Rotation (degrees) (Default 0 degrees): ", 0);
@@ -756,14 +751,14 @@ void CInput::ReadCameraSettings(unsigned int &nCameraId,        int   &nMode,   
     autoExposure = ReadYesNo("Enable Auto Exposure? (y/n): ", false);
     if (autoExposure)
     {
-        exposureCompensation = ReadFloat("Enter Exposure Compensation: ", 0);
+        exposureCompensation = ReadNewFloat("Enter Exposure Compensation: ", 0);
     }
     autoWhiteBalance = ReadYesNo("Enable Auto White Balance? (y/n): ", true);
 }
 
 
-void CInput::ReadCameraSyncOutSettings(unsigned int &nCameraId, int &portNumber, int   &nSyncOutMode, unsigned int &nSyncOutValue,
-                                        float &fSyncOutDutyCycle, bool  &bSyncOutNegativePolarity)
+void CInput::ReadCameraSyncOutSettings(unsigned int& nCameraId, int& portNumber, int* nSyncOutMode, unsigned int* nSyncOutValue,
+                                    float* fSyncOutDutyCycle, bool* bSyncOutNegativePolarity)
 {
     nCameraId = ReadInt("\nEnter Camera ID : ", 1);
     portNumber = ReadInt("Enter Sync out port number (1-3) ", 1);
@@ -779,24 +774,24 @@ void CInput::ReadCameraSyncOutSettings(unsigned int &nCameraId, int &portNumber,
         printf("  6 : Fixed 100 Hz\n");
         printf("  7 : System Live Time\n");
         printf("Select 1 - 7 : ");
-        nSyncOutMode = ReadChar('1', true) - '0';
-        if (nSyncOutMode < 1 || nSyncOutMode > 7)
+        nSyncOutMode = ReadNewCharAsInt('1', true) - '0';
+        if (*nSyncOutMode < 1 || *nSyncOutMode > 7)
         {
-            nSyncOutMode = 1;
+            *nSyncOutMode = 1;
         }
 
-        if (nSyncOutMode >= 2 && nSyncOutMode <= 4)
+        if (*nSyncOutMode >= 2 && *nSyncOutMode <= 4)
         {
-            printf("Enter %s : ", nSyncOutMode == 2 ? "Multiplier" : (nSyncOutMode == 3 ? "Divisor" : "Camera Independent Frequency"));
-            nSyncOutValue = ReadInt("", 1000);
+            printf("Enter %s : ", *nSyncOutMode == 2 ? "Multiplier" : (*nSyncOutMode == 3 ? "Divisor" : "Camera Independent Frequency"));
+            nSyncOutValue = ReadNewUnsignedInt("", 1000);
 
-            fSyncOutDutyCycle = ReadFloat("Enter Sync Out Duty Cycle (%%) : ", 0.5);
+            fSyncOutDutyCycle = ReadNewFloat("Enter Sync Out Duty Cycle (%%) : ", 0.5);
         }
     }
 
-    if (nSyncOutMode < 6)
+    if (*nSyncOutMode < 6)
     {
-        bSyncOutNegativePolarity = ReadYesNo("Negative Polarity? (y/n): ", true);
+        bSyncOutNegativePolarity = ReadNewYesNo("Negative Polarity? (y/n): ", true);
     }
 }
 
@@ -1027,6 +1022,11 @@ float CInput::ReadFloat(const std::string& text, float fDefault)
     return fVal;
 }
 
+float* CInput::ReadNewFloat(const std::string& text, float fDefault)
+{
+    return new float(ReadFloat(text, fDefault));
+}
+
 bool CInput::ReadYesNo(const std::string& text, bool bDefault)
 {
     char c;
@@ -1051,6 +1051,11 @@ bool CInput::ReadYesNo(const std::string& text, bool bDefault)
     return bDefault;
 }
 
+bool* CInput::ReadNewYesNo(const std::string& text, bool bDefault)
+{
+    return new bool(ReadYesNo(text, bDefault));
+}
+
 int CInput::ReadInt(const std::string& text, int nDefault)
 {
     char pStr[128];
@@ -1065,6 +1070,16 @@ int CInput::ReadInt(const std::string& text, int nDefault)
         return nDefault;
     }
     return nVal;
+}
+
+int* CInput::ReadNewInt(const std::string& text, int nDefault)
+{
+    return new int(ReadInt(text, nDefault));
+}
+
+unsigned int* CInput::ReadNewUnsignedInt(const std::string& text, int nDefault)
+{
+    return new unsigned int(static_cast<unsigned int>(ReadInt(text, nDefault)));
 }
 
 char CInput::ReadChar(char cDefault, bool bShowInput)
@@ -1086,6 +1101,16 @@ char CInput::ReadChar(char cDefault, bool bShowInput)
     }
     printf("\n");
     return c;
+}
+
+char* CInput::ReadNewChar(char cDefault, bool bShowInput)
+{
+    return new char(ReadChar(cDefault, bShowInput));
+}
+
+int* CInput::ReadNewCharAsInt(char cDefault, bool bShowInput)
+{
+    return new int(static_cast<int>(ReadChar(cDefault, bShowInput)));
 }
 
 unsigned short CInput::ReadPort(int nDefault)
@@ -1110,6 +1135,11 @@ unsigned short CInput::ReadPort(int nDefault)
     } while (nVal < 1024 || nVal > 65535);
 
     return nVal;
+}
+
+unsigned short* CInput::ReadNewPort(int nDefault)
+{
+    return new unsigned short(ReadPort(nDefault));
 }
 
 bool CInput::ReadUseScrolling(bool &bOutputModeScrolling)

--- a/RTClientExample/Input.h
+++ b/RTClientExample/Input.h
@@ -54,28 +54,28 @@ public:
     void ReadClientControlPassword(std::string& password);
     bool ReadDiscoverRTServers(bool &bDiscover, char* tServerAddress);
     bool ReadOperation(EOperation &eOperation);
-    bool ReadStreamRate(CRTProtocol::EStreamRate &eRate, int &nArg);
+    bool ReadStreamRate(CRTProtocol::EStreamRate &eRate, int& nArg);
     bool ReadDataComponents(unsigned int &nComponentType, char* selectedAnalogChannels, int selectedAnalogChannelsLen, bool &skeletonGlobalReferenceFrame);
-    unsigned int ReadDataComponent(bool printInstr, bool &skeletonGlobalReferenceFrame);
+    unsigned int ReadDataComponent(bool printInstr, bool& skeletonGlobalReferenceFrame);
     bool Read2DNoiseTest();
-    bool ReadDataTest(bool bLogSelection, bool &bStreamTCP, bool &bStreamUDP, bool &bLogToFile, bool &bOnlyTimeAndFrameNumber, unsigned short &nUDPPort, char *tAddress, int nAddressLen);
-    void ReadGeneralSettings(unsigned int &nCaptureFrequency, float &fCaptureTime, bool &bExternalTrigger, bool& trigNO, bool& trigNC, bool& trigSoftware);
+    bool ReadDataTest(bool bLogSelection, bool &bStreamTCP, bool &bStreamUDP, bool &bLogToFile, bool &bOnlyTimeAndFrameNumber, unsigned short& nUDPPort, char *tAddress, int nAddressLen);
+    void ReadGeneralSettings(unsigned int &nCaptureFrequency, float &fCaptureTime, bool* bExternalTrigger, bool* trigNO, bool* trigNC, bool* trigSoftware);
     void ReadProcessingActionsSettings(CRTProtocol::EProcessingActions &eProcessingActions,
                                        CRTProtocol::EProcessingActions &eRtProcessingActions,
                                        CRTProtocol::EProcessingActions &eReprocessingActions);
-    void ReadExtTimeBaseSettings(bool         &bEnabled,            int          &nSignalSource,
-                                 bool         &bSignalModePeriodic, unsigned int &nMultiplier,
-                                 unsigned int &nDivisor,            unsigned int &nFrequencyTolerance,
-                                 float        &fNominalFrequency,   bool         &bNegativeEdge,
-                                 unsigned int &nSignalShutterDelay, float        &fNonPeriodicTimeout);
+    void ReadExtTimeBaseSettings(bool          &bEnabled,           int*          nSignalSource,
+                                 bool*         bSignalModePeriodic, unsigned int* nMultiplier,
+                                 unsigned int* nDivisor,            unsigned int* nFrequencyTolerance,
+                                 float*        fNominalFrequency,   bool*         bNegativeEdge,
+                                 unsigned int* nSignalShutterDelay, float*        fNonPeriodicTimeout);
     void ReadTimestampSettings(CRTProtocol::SSettingsGeneralExternalTimestamp& timestampSettings);
-    void ReadCameraSettings(unsigned int &nCameraId,       int   &nMode,            CRTProtocol::EVideoResolution &videoResolution, CRTProtocol::EVideoAspectRatio &videoAspectRatio,
-                            unsigned int &nVideoFrequency, float &fVideoExposure,   float &fVideoFlashTime,
-                            float        &fMarkerExposure, float &fMarkerThreshold, int   &nRotation,
-                            float        &fFocus,          float &fAperture,        bool  &autoExposure,
-                            float        &exposureCompensation, bool &autoWhiteBalance);
-    void ReadCameraSyncOutSettings(unsigned int &nCameraId,         int &portNumber, int  &nSyncOutMode, unsigned int &nSyncOutValue,
-                                    float        &fSyncOutDutyCycle, bool &bSyncOutNegativePolarity);
+    void ReadCameraSettings(unsigned int& nCameraId,           int&   nMode,            CRTProtocol::EVideoResolution* videoResolution, CRTProtocol::EVideoAspectRatio* videoAspectRatio,
+                            unsigned int* nVideoFrequency,     float* fVideoExposure,   float* fVideoFlashTime,
+                            float*        fMarkerExposure,     float* fMarkerThreshold, int&   nRotation,
+                            float&        fFocus,              float& fAperture,        bool&  autoExposure,
+                            float*        exposureCompensation, bool& autoWhiteBalance);
+    void ReadCameraSyncOutSettings(unsigned int& nCameraId, int& portNumber, int* nSyncOutMode, unsigned int* nSyncOutValue,
+                                    float* fSyncOutDutyCycle, bool* bSyncOutNegativePolarity);
 
     void ReadImageSettings(unsigned int &nCameraId, bool &bEnable, int &nFormat, unsigned int &nWidth,
                            unsigned int &nHeight, float &fLeftCrop, float &fTopCrop, float &fRightCrop, float &fBottomCrop);
@@ -88,10 +88,17 @@ public:
 
     std::string ReadString(const std::string& text);
     float       ReadFloat(const std::string& text, float fDefault);
+    float*      ReadNewFloat(const std::string& text, float fDefault);
     bool        ReadYesNo(const std::string& text, bool bDefault);
+    bool*       ReadNewYesNo(const std::string& text, bool bDefault);
     int         ReadInt(const std::string& text, int nDefault);
+    int*        ReadNewInt(const std::string& text, int nDefault);
+    unsigned int* ReadNewUnsignedInt(const std::string& text, int nDefault);
     char        ReadChar(char cDefault, bool bShowInput = false);
+    char*       ReadNewChar(char cDefault, bool bShowInput);
+    int*        ReadNewCharAsInt(char cDefault, bool bShowInput);
     unsigned short ReadPort(int nDefault);
+    unsigned short* ReadNewPort(int nDefault);
     bool        ReadUseScrolling(bool &bOutputModeScrolling);
 
 private:

--- a/RTClientExample/Input.h
+++ b/RTClientExample/Input.h
@@ -59,23 +59,23 @@ public:
     unsigned int ReadDataComponent(bool printInstr, bool& skeletonGlobalReferenceFrame);
     bool Read2DNoiseTest();
     bool ReadDataTest(bool bLogSelection, bool &bStreamTCP, bool &bStreamUDP, bool &bLogToFile, bool &bOnlyTimeAndFrameNumber, unsigned short& nUDPPort, char *tAddress, int nAddressLen);
-    void ReadGeneralSettings(unsigned int &nCaptureFrequency, float &fCaptureTime, bool* bExternalTrigger, bool* trigNO, bool* trigNC, bool* trigSoftware);
+    void ReadGeneralSettings(unsigned int& nCaptureFrequency, float& fCaptureTime, bool*& bExternalTrigger, bool*& trigNO, bool*& trigNC, bool*& trigSoftware);
     void ReadProcessingActionsSettings(CRTProtocol::EProcessingActions &eProcessingActions,
                                        CRTProtocol::EProcessingActions &eRtProcessingActions,
                                        CRTProtocol::EProcessingActions &eReprocessingActions);
-    void ReadExtTimeBaseSettings(bool          &bEnabled,           int*          nSignalSource,
-                                 bool*         bSignalModePeriodic, unsigned int* nMultiplier,
-                                 unsigned int* nDivisor,            unsigned int* nFrequencyTolerance,
-                                 float*        fNominalFrequency,   bool*         bNegativeEdge,
-                                 unsigned int* nSignalShutterDelay, float*        fNonPeriodicTimeout);
+    void ReadExtTimeBaseSettings(bool          &bEnabled,           int*&          nSignalSource,
+                                 bool*&         bSignalModePeriodic, unsigned int*& nMultiplier,
+                                 unsigned int*& nDivisor,            unsigned int*& nFrequencyTolerance,
+                                 float*&        fNominalFrequency,   bool*&         bNegativeEdge,
+                                 unsigned int*& nSignalShutterDelay, float*&        fNonPeriodicTimeout);
     void ReadTimestampSettings(CRTProtocol::SSettingsGeneralExternalTimestamp& timestampSettings);
-    void ReadCameraSettings(unsigned int& nCameraId,           int&   nMode,            CRTProtocol::EVideoResolution* videoResolution, CRTProtocol::EVideoAspectRatio* videoAspectRatio,
-                            unsigned int* nVideoFrequency,     float* fVideoExposure,   float* fVideoFlashTime,
-                            float*        fMarkerExposure,     float* fMarkerThreshold, int&   nRotation,
+    void ReadCameraSettings(unsigned int& nCameraId,           int&   nMode,            CRTProtocol::EVideoResolution*& videoResolution, CRTProtocol::EVideoAspectRatio*& videoAspectRatio,
+                            unsigned int*& nVideoFrequency,     float*& fVideoExposure,   float*& fVideoFlashTime,
+                            float*&        fMarkerExposure,     float*& fMarkerThreshold, int&   nRotation,
                             float&        fFocus,              float& fAperture,        bool&  autoExposure,
-                            float*        exposureCompensation, bool& autoWhiteBalance);
-    void ReadCameraSyncOutSettings(unsigned int& nCameraId, int& portNumber, int* nSyncOutMode, unsigned int* nSyncOutValue,
-                                    float* fSyncOutDutyCycle, bool* bSyncOutNegativePolarity);
+                            float&        exposureCompensation, bool& autoWhiteBalance);
+    void ReadCameraSyncOutSettings(unsigned int& nCameraId, int& portNumber, int*& nSyncOutMode, unsigned int*& nSyncOutValue,
+                                    float*& fSyncOutDutyCycle, bool*& bSyncOutNegativePolarity);
 
     void ReadImageSettings(unsigned int &nCameraId, bool &bEnable, int &nFormat, unsigned int &nWidth,
                            unsigned int &nHeight, float &fLeftCrop, float &fTopCrop, float &fRightCrop, float &fBottomCrop);

--- a/RTClientExample/Operations.cpp
+++ b/RTClientExample/Operations.cpp
@@ -252,14 +252,14 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
 
                 unsigned int nCaptureFrequency;
                 float fCaptureTime;
-                bool bExternalTrigger;
-                bool startOnTrigNO;
-                bool startOnTrigNC;
-                bool startOnTrigSoftware;
+                bool* bExternalTrigger = nullptr;
+                bool* startOnTrigNO = nullptr;
+                bool* startOnTrigNC = nullptr;
+                bool* startOnTrigSoftware = nullptr;
 
                 mpoInput->ReadGeneralSettings(nCaptureFrequency, fCaptureTime, bExternalTrigger, startOnTrigNO, startOnTrigNC, startOnTrigSoftware);
 
-                if (mpoRTProtocol->SetGeneralSettings(&nCaptureFrequency, &fCaptureTime, &bExternalTrigger, &startOnTrigNO, &startOnTrigNC, &startOnTrigSoftware, NULL, NULL, NULL))
+                if (mpoRTProtocol->SetGeneralSettings(&nCaptureFrequency, &fCaptureTime, bExternalTrigger, startOnTrigNO, startOnTrigNC, startOnTrigSoftware, NULL, NULL, NULL))
                 {
                     printf("Change General Settings Succeeded\n\n");
                 }
@@ -267,20 +267,25 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
                 {
                     printf("Change General Settings Failed\n\n");
                 }
+
+                delete bExternalTrigger;
+                delete startOnTrigNO;
+                delete startOnTrigNC;
+                delete startOnTrigSoftware;
             }
 
             if (eOperation == CInput::ChangeExtTimebaseSettings)
             {
-                bool         bEnabled;
-                int          nSignalSource;
-                bool         bSignalModePeriodic;
-                unsigned int nMultiplier;
-                unsigned int nDivisor;
-                unsigned int nFrequencyTolerance;
-                float        fNominalFrequency;
-                bool         bNegativeEdge;
-                unsigned int nSignalShutterDelay;
-                float        fNonPeriodicTimeout;
+                bool          bEnabled;
+                int*          nSignalSource = nullptr;
+                bool*         bSignalModePeriodic = nullptr;
+                unsigned int* nMultiplier = nullptr;
+                unsigned int* nDivisor = nullptr;
+                unsigned int* nFrequencyTolerance = nullptr;
+                float*        fNominalFrequency = nullptr;
+                bool*         bNegativeEdge = nullptr;
+                unsigned int* nSignalShutterDelay = nullptr;
+                float*        fNonPeriodicTimeout = nullptr;
 
                 printf("\n\nInput External Time Base Settings\n\n");
 
@@ -289,10 +294,10 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
                                                          fNominalFrequency, bNegativeEdge, nSignalShutterDelay,
                                                          fNonPeriodicTimeout);
 
-                if (mpoRTProtocol->SetExtTimeBaseSettings(&bEnabled,            (CRTProtocol::ESignalSource*)&nSignalSource,
-                                                         &bSignalModePeriodic, &nMultiplier,       &nDivisor,      
-                                                         &nFrequencyTolerance, &fNominalFrequency, &bNegativeEdge,
-                                                         &nSignalShutterDelay, &fNonPeriodicTimeout))
+                if (mpoRTProtocol->SetExtTimeBaseSettings(&bEnabled,            (CRTProtocol::ESignalSource*)nSignalSource,
+                                                         bSignalModePeriodic, nMultiplier,       nDivisor,      
+                                                         nFrequencyTolerance, fNominalFrequency, bNegativeEdge,
+                                                         nSignalShutterDelay, fNonPeriodicTimeout))
                 {
                     printf("Change External Time Base Settings Succeeded\n\n");
                 }
@@ -300,6 +305,16 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
                 {
                     printf("Change External Time Base Settings Failed\n\n");
                 }
+
+                delete nSignalSource;
+                delete bSignalModePeriodic;
+                delete nMultiplier;
+                delete nDivisor;
+                delete nFrequencyTolerance;
+                delete fNominalFrequency;
+                delete bNegativeEdge;
+                delete nSignalShutterDelay;
+                delete fNonPeriodicTimeout;
             }
 
             if (eOperation == CInput::ChangeExtTimestampSettings)
@@ -341,38 +356,23 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
                 printf("\n\nInput Camera Settings\n\n");
 
                 int           nMode;
-                unsigned int  nVideoFrequency  = -1;
-                float         fVideoExposure   = -1;
-                float         fVideoFlashTime  = -1;
-                float         fMarkerExposure  = -1;
-                float         fMarkerThreshold = -1;
-                CRTProtocol::EVideoResolution videoResolution;
-                CRTProtocol::EVideoAspectRatio videoAspectRatio;
-                CRTProtocol::EVideoResolution* pVideoResolution;
-                CRTProtocol::EVideoAspectRatio* pVideoAspectRatio;
+                CRTProtocol::EVideoResolution* pVideoResolution = nullptr;
+                CRTProtocol::EVideoAspectRatio* pVideoAspectRatio = nullptr;
                 int           nRotation;
-                unsigned int* pnVideoFrequency;
-                float*        pfVideoExposure;
-                float*        pfVideoFlashTime;
-                float*        pfMarkerExposure;
-                float*        pfMarkerThreshold;
+                unsigned int* pnVideoFrequency = nullptr;
+                float*        pfVideoExposure = nullptr;
+                float*        pfVideoFlashTime = nullptr;
+                float*        pfMarkerExposure = nullptr;
+                float*        pfMarkerThreshold = nullptr;
                 float         fFocus;
                 float         fAperture;
                 bool          autoExposure;
-                float         exposureCompensation;
+                float*        pfExposureCompensation = nullptr;
                 bool          autoWhiteBalance;
 
-                mpoInput->ReadCameraSettings(nCameraId, nMode, videoResolution, videoAspectRatio, nVideoFrequency, 
-                                             fVideoExposure, fVideoFlashTime, fMarkerExposure,
-                                             fMarkerThreshold, nRotation, fFocus, fAperture, autoExposure, exposureCompensation, autoWhiteBalance);
-
-                pnVideoFrequency  = (nVideoFrequency == -1) ? NULL : &nVideoFrequency;
-                pfVideoExposure   = (fVideoExposure == -1) ? NULL : &fVideoExposure;
-                pfVideoFlashTime  = (fVideoFlashTime == -1) ? NULL : &fVideoFlashTime;
-                pfMarkerExposure  = (fMarkerExposure == -1) ? NULL : &fMarkerExposure;
-                pfMarkerThreshold = (fMarkerThreshold == -1) ? NULL : &fMarkerThreshold;
-                pVideoResolution = (videoResolution == CRTProtocol::EVideoResolution::VideoResolutionNone) ? NULL : &videoResolution;
-                pVideoAspectRatio = (videoAspectRatio == CRTProtocol::EVideoAspectRatio::VideoAspectRatioNone) ? NULL : &videoAspectRatio;
+                mpoInput->ReadCameraSettings(nCameraId, nMode, pVideoResolution, pVideoAspectRatio, pnVideoFrequency,
+                                             pfVideoExposure, pfVideoFlashTime, pfMarkerExposure,
+                                             pfMarkerThreshold, nRotation, fFocus, fAperture, autoExposure, pfExposureCompensation, autoWhiteBalance);
 
                 if (mpoRTProtocol->SetCameraSettings(nCameraId, (CRTProtocol::ECameraMode*)&nMode, 
                                                      pfMarkerExposure, pfMarkerThreshold, &nRotation))
@@ -402,7 +402,7 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
                     printf("Change Camera Lens Control Settings Failed\n\n");
                 }
 
-                if (mpoRTProtocol->SetCameraAutoExposureSettings(nCameraId, autoExposure, exposureCompensation))
+                if (mpoRTProtocol->SetCameraAutoExposureSettings(nCameraId, autoExposure, *pfExposureCompensation))
                 {
                     printf("Change Camera Lens Control Settings Succeeded\n\n");
                 }
@@ -419,24 +419,33 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
                 {
                     printf("Change Camera Auto White Balance Settings Failed\n\n");
                 }
+
+                delete pVideoResolution;
+                delete pVideoAspectRatio;
+                delete pnVideoFrequency;
+                delete pfVideoExposure;
+                delete pfVideoFlashTime;
+                delete pfMarkerExposure;
+                delete pfMarkerThreshold;
+                delete pfExposureCompensation;
             }
 
             if (eOperation == CInput::ChangeCameraSyncOutSettings)
             {
                 printf("\n\nInput Camera Sync Out Settings\n\n");
 
-                int          portNumber;
-                int          nSyncOutMode;
-                unsigned int nSyncOutValue;
-                float        fSyncOutDutyCycle;
-                bool         bSyncOutNegativePolarity;
+                int           portNumber;
+                int*          nSyncOutMode = nullptr;
+                unsigned int* nSyncOutValue = nullptr;
+                float*        fSyncOutDutyCycle = nullptr;
+                bool*         bSyncOutNegativePolarity = nullptr;
 
                 mpoInput->ReadCameraSyncOutSettings(nCameraId, portNumber, nSyncOutMode, nSyncOutValue, fSyncOutDutyCycle,
                                                      bSyncOutNegativePolarity);
 
-                if (mpoRTProtocol->SetCameraSyncOutSettings(nCameraId, portNumber, (CRTProtocol::ESyncOutFreqMode*)&nSyncOutMode,
-                                                           &nSyncOutValue, &fSyncOutDutyCycle,
-                                                           &bSyncOutNegativePolarity))
+                if (mpoRTProtocol->SetCameraSyncOutSettings(nCameraId, portNumber, (CRTProtocol::ESyncOutFreqMode*)nSyncOutMode,
+                                                           nSyncOutValue, fSyncOutDutyCycle,
+                                                           bSyncOutNegativePolarity))
                 {
                     printf("Change Camera Sync Out Settings Succeeded\n\n");
                 }
@@ -444,6 +453,11 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
                 {
                     printf("Change Camera Syn Out Settings Failed\n\n");
                 }
+
+                 delete nSyncOutMode;
+                 delete nSyncOutValue;
+                 delete fSyncOutDutyCycle;
+                 delete bSyncOutNegativePolarity;
             }
 
             if (eOperation == CInput::ChangeImageSettings)
@@ -555,7 +569,6 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
             }
         }
     } while (!bGotControl && !password.empty());
-
 } // ChangeSettings
 
 
@@ -565,7 +578,7 @@ void COperations::DataTransfer(CInput::EOperation operation)
     unsigned int                nComponentType;
     char                        selectedAnalogChannels[256];
     CRTProtocol::EStreamRate    eStreamRate;
-    int                         nRateArgument = 0;
+    int                         nRateArgument;
     FILE*                       logfile = NULL;
     bool                        bStreamTCP, bStreamUDP, bLogToFile, bOnlyTimeAndFrameNumber;
     unsigned short              nUDPPort;
@@ -581,7 +594,7 @@ void COperations::DataTransfer(CInput::EOperation operation)
         bStreamUDP = false;
         bLogToFile = false;
         bOnlyTimeAndFrameNumber = false;
-        nUDPPort = 0;
+        nUDPPort;
         tUDPAddress[0] = 0;
         eStreamRate = CRTProtocol::RateAllFrames;
 

--- a/RTClientExample/Operations.cpp
+++ b/RTClientExample/Operations.cpp
@@ -367,12 +367,12 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
                 float         fFocus;
                 float         fAperture;
                 bool          autoExposure;
-                float*        pfExposureCompensation = nullptr;
+                float         fExposureCompensation = 0.0f;
                 bool          autoWhiteBalance;
 
                 mpoInput->ReadCameraSettings(nCameraId, nMode, pVideoResolution, pVideoAspectRatio, pnVideoFrequency,
                                              pfVideoExposure, pfVideoFlashTime, pfMarkerExposure,
-                                             pfMarkerThreshold, nRotation, fFocus, fAperture, autoExposure, pfExposureCompensation, autoWhiteBalance);
+                                             pfMarkerThreshold, nRotation, fFocus, fAperture, autoExposure, fExposureCompensation, autoWhiteBalance);
 
                 if (mpoRTProtocol->SetCameraSettings(nCameraId, (CRTProtocol::ECameraMode*)&nMode, 
                                                      pfMarkerExposure, pfMarkerThreshold, &nRotation))
@@ -402,7 +402,7 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
                     printf("Change Camera Lens Control Settings Failed\n\n");
                 }
 
-                if (mpoRTProtocol->SetCameraAutoExposureSettings(nCameraId, autoExposure, *pfExposureCompensation))
+                if (mpoRTProtocol->SetCameraAutoExposureSettings(nCameraId, autoExposure, fExposureCompensation))
                 {
                     printf("Change Camera Lens Control Settings Succeeded\n\n");
                 }
@@ -427,7 +427,6 @@ void COperations::ChangeSettings(CInput::EOperation eOperation)
                 delete pfVideoFlashTime;
                 delete pfMarkerExposure;
                 delete pfMarkerThreshold;
-                delete pfExposureCompensation;
             }
 
             if (eOperation == CInput::ChangeCameraSyncOutSettings)

--- a/RTClientExample/Operations.cpp
+++ b/RTClientExample/Operations.cpp
@@ -578,7 +578,7 @@ void COperations::DataTransfer(CInput::EOperation operation)
     unsigned int                nComponentType;
     char                        selectedAnalogChannels[256];
     CRTProtocol::EStreamRate    eStreamRate;
-    int                         nRateArgument;
+    int                         nRateArgument = 0;
     FILE*                       logfile = NULL;
     bool                        bStreamTCP, bStreamUDP, bLogToFile, bOnlyTimeAndFrameNumber;
     unsigned short              nUDPPort;
@@ -594,7 +594,7 @@ void COperations::DataTransfer(CInput::EOperation operation)
         bStreamUDP = false;
         bLogToFile = false;
         bOnlyTimeAndFrameNumber = false;
-        nUDPPort;
+        nUDPPort = 0;
         tUDPAddress[0] = 0;
         eStreamRate = CRTProtocol::RateAllFrames;
 


### PR DESCRIPTION
The RTClientExample wasn't working correctly in some instances because references being used were uninitialized. These parameters that can be uninitialized have been changed to be pointers instead.