### PR TITLE
Fix Clang Compiler Warnings (Errors)

### DIFF
--- a/RTPacket.h
+++ b/RTPacket.h
@@ -312,7 +312,6 @@ private:
     std::vector<char*> mpTimecodeData;
     std::vector<char*> mpSkeletonData;
     unsigned int   mnComponentCount;
-    EComponentType meComponentType;
     unsigned int   mn2DCameraCount;
     unsigned int   mn2DLinCameraCount;
     unsigned int   mnImageCameraCount;

--- a/SettingsDeserializer.cpp
+++ b/SettingsDeserializer.cpp
@@ -264,7 +264,7 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
         &generalSettings.eReprocessingActions
     };
 
-    auto AddFlagFromBoolElement = [&](Deserializer& parent, const char* elementName, EProcessingActions flag,
+    auto AddFlagFromBoolElement = [](Deserializer& parent, const char* elementName, EProcessingActions flag,
                                          EProcessingActions& target) -> bool
     {
         bool value;

--- a/SettingsDeserializer.cpp
+++ b/SettingsDeserializer.cpp
@@ -264,7 +264,7 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
         &generalSettings.eReprocessingActions
     };
 
-    auto AddFlagFromBoolElement = [this](Deserializer& parent, const char* elementName, EProcessingActions flag,
+    auto AddFlagFromBoolElement = [&](Deserializer& parent, const char* elementName, EProcessingActions flag,
                                          EProcessingActions& target) -> bool
     {
         bool value;

--- a/SettingsDeserializer.cpp
+++ b/SettingsDeserializer.cpp
@@ -264,7 +264,7 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
         &generalSettings.eReprocessingActions
     };
 
-    auto AddFlagFromBoolElement = [](Deserializer& parent, const char* elementName, EProcessingActions flag,
+    auto addFlagFromBoolElement = [](Deserializer& parent, const char* elementName, EProcessingActions flag,
                                          EProcessingActions& target) -> bool
     {
         bool value;
@@ -293,7 +293,7 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
 
         if (mMajorVersion > 1 || mMinorVersion > 13)
         {
-            if (!AddFlagFromBoolElement(processingElem, "PreProcessing2D", ProcessingPreProcess2D,
+            if (!addFlagFromBoolElement(processingElem, "PreProcessing2D", ProcessingPreProcess2D,
                                         *processingActions[i]))
             {
                 return false;
@@ -318,36 +318,36 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
 
         if (i != 1) //Not RtProcessingSettings
         {
-            if (!AddFlagFromBoolElement(processingElem, "TwinSystemMerge", ProcessingTwinSystemMerge,
+            if (!addFlagFromBoolElement(processingElem, "TwinSystemMerge", ProcessingTwinSystemMerge,
                                         *processingActions[i]))
             {
                 return false;
             }
 
-            if (!AddFlagFromBoolElement(processingElem, "SplineFill", ProcessingSplineFill, *processingActions[i]))
+            if (!addFlagFromBoolElement(processingElem, "SplineFill", ProcessingSplineFill, *processingActions[i]))
             {
                 return false;
             }
         }
 
-        if (!AddFlagFromBoolElement(processingElem, "AIM", ProcessingAIM, *processingActions[i]))
+        if (!addFlagFromBoolElement(processingElem, "AIM", ProcessingAIM, *processingActions[i]))
         {
             return false;
         }
 
-        if (!AddFlagFromBoolElement(processingElem, "Track6DOF", Processing6DOFTracking, *processingActions[i]))
+        if (!addFlagFromBoolElement(processingElem, "Track6DOF", Processing6DOFTracking, *processingActions[i]))
         {
             return false;
         }
 
-        if (!AddFlagFromBoolElement(processingElem, "ForceData", ProcessingForceData, *processingActions[i]))
+        if (!addFlagFromBoolElement(processingElem, "ForceData", ProcessingForceData, *processingActions[i]))
         {
             return false;
         }
 
         if (mMajorVersion > 1 || mMinorVersion > 11)
         {
-            if (!AddFlagFromBoolElement(processingElem, "GazeVector", ProcessingGazeVector, *processingActions[i]))
+            if (!addFlagFromBoolElement(processingElem, "GazeVector", ProcessingGazeVector, *processingActions[i]))
             {
                 return false;
             }
@@ -355,17 +355,17 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
 
         if (i != 1) //Not RtProcessingSettings
         {
-            if (!AddFlagFromBoolElement(processingElem, "ExportTSV", ProcessingExportTSV, *processingActions[i]))
+            if (!addFlagFromBoolElement(processingElem, "ExportTSV", ProcessingExportTSV, *processingActions[i]))
             {
                 return false;
             }
 
-            if (!AddFlagFromBoolElement(processingElem, "ExportC3D", ProcessingExportC3D, *processingActions[i]))
+            if (!addFlagFromBoolElement(processingElem, "ExportC3D", ProcessingExportC3D, *processingActions[i]))
             {
                 return false;
             }
 
-            if (!AddFlagFromBoolElement(processingElem, "ExportMatlabFile", ProcessingExportMatlabFile,
+            if (!addFlagFromBoolElement(processingElem, "ExportMatlabFile", ProcessingExportMatlabFile,
                                         *processingActions[i]))
             {
                 return false;
@@ -373,7 +373,7 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
 
             if (mMajorVersion > 1 || mMinorVersion > 11)
             {
-                if (!AddFlagFromBoolElement(processingElem, "ExportAviFile", ProcessingExportAviFile,
+                if (!addFlagFromBoolElement(processingElem, "ExportAviFile", ProcessingExportAviFile,
                                             *processingActions[i]))
                 {
                     return false;

--- a/Tests/SkeletonParametersTests.cpp
+++ b/Tests/SkeletonParametersTests.cpp
@@ -85,13 +85,13 @@ namespace
 
     std::vector<CRTProtocol::SSettingsSkeleton> CreateDummySkeletonsNonHierarchical()
     {
-        auto segmentsSkeleton1 = std::vector<CRTProtocol::SSettingsSkeletonSegment>{
+        auto segmentsSkeleton1 = std::vector<CRTProtocol::SSettingsSkeletonSegment>({
             { 0, 0.0f, 1.0f, 2.0f, 0.707000017f, -0.707000017f, 0.0f, 0.0f, "segment1", -1, -1 },
             { 0, 3.0f, 4.0f, 5.0f, 0.707000017f, 0.707000017f, 0.0f, 0.0f, "segment3", 0, 1 }
-        };
-        auto segmentsSkeleton2 = std::vector<CRTProtocol::SSettingsSkeletonSegment>{
+        });
+        auto segmentsSkeleton2 = std::vector<CRTProtocol::SSettingsSkeletonSegment>({
             { 0, 0.0f, 1.0f, 2.0f, 0.707000017f, 0.0f, 0.707000017f, 0.0f, "segment2", -1, -1 }
-        };
+        });
 
         CRTProtocol::SSettingsSkeleton skeleton1 = { "skeleton1", segmentsSkeleton1 };
         CRTProtocol::SSettingsSkeleton skeleton2 = { "skeleton2", segmentsSkeleton2 };

--- a/Tests/SkeletonParametersTests.cpp
+++ b/Tests/SkeletonParametersTests.cpp
@@ -86,11 +86,11 @@ namespace
     std::vector<CRTProtocol::SSettingsSkeleton> CreateDummySkeletonsNonHierarchical()
     {
         auto segmentsSkeleton1 = std::vector<CRTProtocol::SSettingsSkeletonSegment>({
-            { 0, 0.0f, 1.0f, 2.0f, 0.707000017f, -0.707000017f, 0.0f, 0.0f, "segment1", -1, -1 },
-            { 0, 3.0f, 4.0f, 5.0f, 0.707000017f, 0.707000017f, 0.0f, 0.0f, "segment3", 0, 1 }
+            { { 0, 0.0f, 1.0f, 2.0f, 0.707000017f, -0.707000017f, 0.0f, 0.0f }, "segment1", -1, -1 },
+            { { 0, 3.0f, 4.0f, 5.0f, 0.707000017f, 0.707000017f, 0.0f, 0.0f }, "segment3", 0, 1 }
         });
         auto segmentsSkeleton2 = std::vector<CRTProtocol::SSettingsSkeletonSegment>({
-            { 0, 0.0f, 1.0f, 2.0f, 0.707000017f, 0.0f, 0.707000017f, 0.0f, "segment2", -1, -1 }
+            { { 0, 0.0f, 1.0f, 2.0f, 0.707000017f, 0.0f, 0.707000017f, 0.0f }, "segment2", -1, -1 }
         });
 
         CRTProtocol::SSettingsSkeleton skeleton1 = { "skeleton1", segmentsSkeleton1 };


### PR DESCRIPTION
When compiling with Clang on Windows / Linux there were a few warnings that didn't appear in the other compilers we tested:
- Unused private member variable
- Unused 'this' sent into lambda function
- Incorrect vector constructor syntax
- Missing curly brackets from subobjects in initializer list provided to vector

---

# Tests Run
- Compiled with Clang (Windows)
- Compiled with Clang (Ubuntu)
- Compiled with MSVC
- Compiled with GNU
- Compiled with CMake / Visual Studio
  - Successfully ran tests using this compilation