### PR TITLE
Add action to run build and test on all PRs

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,0 +1,62 @@
+name: CMake on multiple platforms
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        build_type: [Release]
+        c_compiler: [gcc, clang, cl]
+        include:
+          # Windows + MSVC
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+
+          # Ubuntu + GCC
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+
+          # Ubuntu + Clang
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+
+        # Exclude invalid combos (e.g., trying gcc on Windows)
+        exclude:
+          - os: windows-latest
+            c_compiler: gcc
+          - os: windows-latest
+            c_compiler: clang
+          - os: ubuntu-latest
+            c_compiler: cl
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true  # Important: pulls in any Git submodules
+
+      - name: Configure CMake
+        # Single-line command works on both Windows (PowerShell) & Linux (Bash).
+        run: cmake -S . -B build -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}  -Dqualisys_cpp_sdk_BUILD_TESTS=ON
+
+      - name: Build
+        # On Windows + MSVC (multi-config generator), --config picks Release/Debug.
+        # On Linux + Make/Ninja (single-config), --config is simply ignored, which is fine.
+        run: cmake --build build --config ${{ matrix.build_type }}
+
+      - name: Test
+        working-directory: build
+        # --build-config is needed for multi-config Windows. Linux ignores it, which is okay.
+        run: ctest --build-config ${{ matrix.build_type }} --output-on-failure


### PR DESCRIPTION
## [CI] Add Cross-Platform CMake Build and Test

**TL;DR**:  
This PR introduces a GitHub Actions workflow that builds and tests the SDK on **Windows (MSVC)** and **Ubuntu (GCC/Clang)**. It checks out submodules, configures CMake, builds in **Release** mode, then runs **ctest**.

### Summary

- Builds on:
  - **Ubuntu-latest** with GCC and Clang
  - **Windows-latest** with MSVC
- Uses **CMake** to configure and build the project
- Automatically **runs tests** (via ctest) to ensure everything passes
- Matrix strategy excludes invalid OS/compiler combos (e.g., gcc on Windows)

### Why This is Needed

- Ensures we detect cross-platform issues early
- Automates testing, saving time on manual verification
- Helps maintain code quality and stability

### Notes

- The workflow triggers on:
  - **Push** events to `master`
  - **Pull requests** from any branch
- `fail-fast: false` means we see results from all matrix jobs even if one fails
- Had to write the cmake command on one line since line breaks over different prompts was hard to manage.
