### PR TITLE
Fixes missing skeleton segment IDs

### DIFF
--- a/SettingsDeserializer.cpp
+++ b/SettingsDeserializer.cpp
@@ -1913,7 +1913,7 @@ bool SettingsDeserializer::DeserializeSkeletonSettings(bool skeletonGlobalData,
                 {
                     segmentHierarchical.name = segmentElem.ReadAttributeString("Name");
 
-                    segmentElem.TryReadElementUnsignedInt32("ID", segmentHierarchical.id);
+                    segmentHierarchical.id = segmentElem.ReadAttributeInt("ID");
                     segmentIdIndexMap[segmentHierarchical.id] = segmentIndex++;
 
                     segmentElem.TryReadElementString("Solver", segmentHierarchical.solver);

--- a/Tests/Data/Skeleton.h
+++ b/Tests/Data/Skeleton.h
@@ -1,6 +1,134 @@
 #pragma once
 namespace qualisys_cpp_sdk::tests::data
 {
+    inline const char* SkeletonSettingsGet = R"XMLDATA(
+<QTM_Settings>
+    <Skeletons>
+        <Skeleton Name="skeleton1">
+            <Scale>1.100000</Scale>
+            <Segments>
+                <Segment Name="segment1" ID="1">
+                    <Solver>Global Optimization</Solver>
+                    <Transform>
+                        <Position X="0.000000" Y="1.000000" Z="2.000000"/>
+                        <Rotation X="0.000000" Y="0.000000" Z="0.000000" W="1.000000"/>
+                    </Transform>
+                    <DefaultTransform>
+                        <Position X="0.000000" Y="1.000000" Z="2.000000"/>
+                        <Rotation X="0.707000" Y="-0.707000" Z="0.000000" W="0.000000"/>
+                    </DefaultTransform>
+                    <DegreesOfFreedom>
+                        <RotationX>
+                            <Constraint LowerBound="2.300000" UpperBound="3.200000"/>
+                            <Couplings>
+                                <Coupling Segment="segment1" DegreeOfFreedom="RotationX" Coefficient="5.500000"/>
+                            </Couplings>
+                            <Goal Value="4.100000" Weight="1.400000"/>
+                        </RotationX>
+                    </DegreesOfFreedom>
+                    <Endpoint X="0.000000" Y="1.000000" Z="2.000000"/>
+                    <Markers>
+                        <Marker Name="marker1">
+                            <Position X="1.000000" Y="2.000000" Z="3.000000"/>
+                            <Weight>3.000000</Weight>
+                        </Marker>
+                        <Marker Name="marker2">
+                            <Position X="4.000000" Y="5.000000" Z="6.000000"/>
+                            <Weight>7.000000</Weight>
+                        </Marker>
+                    </Markers>
+                    <RigidBodies>
+                        <RigidBody Name="body1">
+                            <Transform>
+                                <Position X="1.000000" Y="2.000000" Z="3.000000"/>
+                                <Rotation X="1.000000" Y="2.000000" Z="3.000000" W="4.000000"/>
+                            </Transform>
+                            <Weight>3.000000</Weight>
+                        </RigidBody>
+                        <RigidBody Name="body2">
+                            <Transform>
+                                <Position X="4.000000" Y="5.000000" Z="6.000000"/>
+                                <Rotation X="5.000000" Y="6.000000" Z="7.000000" W="8.000000"/>
+                            </Transform>
+                            <Weight>7.000000</Weight>
+                        </RigidBody>
+                    </RigidBodies>
+                    <Segment Name="segment3" ID="3">
+                        <Solver>Global Optimization</Solver>
+                        <Transform>
+                            <Position X="10.000000" Y="11.000000" Z="12.000000"/>
+                            <Rotation X="0.000000" Y="0.000000" Z="0.000000" W="1.000000"/>
+                        </Transform>
+                        <DefaultTransform>
+                            <Position X="3.000000" Y="4.000000" Z="5.000000"/>
+                            <Rotation X="0.707000" Y="0.707000" Z="0.000000" W="0.000000"/>
+                        </DefaultTransform>
+                        <DegreesOfFreedom>
+                            <RotationX>
+                                <Constraint LowerBound="2.300000" UpperBound="3.200000"/>
+                                <Couplings>
+                                    <Coupling Segment="segment1" DegreeOfFreedom="RotationX" Coefficient="5.500000"/>
+                                </Couplings>
+                                <Goal Value="4.100000" Weight="1.400000"/>
+                            </RotationX>
+                        </DegreesOfFreedom>
+                        <Endpoint X="0.000000" Y="1.000000" Z="2.000000"/>
+                        <Markers>
+                            <Marker Name="marker1">
+                                <Position X="1.000000" Y="2.000000" Z="3.000000"/>
+                                <Weight>3.000000</Weight>
+                            </Marker>
+                            <Marker Name="marker2">
+                                <Position X="4.000000" Y="5.000000" Z="6.000000"/>
+                                <Weight>7.000000</Weight>
+                            </Marker>
+                        </Markers>
+                        <RigidBodies/>
+                    </Segment>
+                </Segment>
+            </Segments>
+        </Skeleton>
+        <Skeleton Name="skeleton2">
+            <Scale>1.000000</Scale>
+            <Segments>
+                <Segment Name="segment2" ID="2">
+                    <Solver>Global Optimization</Solver>
+                    <Transform>
+                        <Position X="0.000000" Y="1.000000" Z="2.000000"/>
+                        <Rotation X="0.000000" Y="0.000000" Z="0.000000" W="1.000000"/>
+                    </Transform>
+                    <DefaultTransform>
+                        <Position X="0.000000" Y="1.000000" Z="2.000000"/>
+                        <Rotation X="0.707000" Y="0.000000" Z="0.707000" W="0.000000"/>
+                    </DefaultTransform>
+                    <DegreesOfFreedom>
+                        <RotationX>
+                            <Constraint LowerBound="2.300000" UpperBound="3.200000"/>
+                            <Couplings>
+                                <Coupling Segment="segment1" DegreeOfFreedom="RotationX" Coefficient="5.500000"/>
+                            </Couplings>
+                            <Goal Value="4.100000" Weight="1.400000"/>
+                        </RotationX>
+                    </DegreesOfFreedom>
+                    <Endpoint X="0.000000" Y="1.000000" Z="2.000000"/>
+                    <Markers>
+                        <Marker Name="marker1">
+                            <Position X="1.000000" Y="2.000000" Z="3.000000"/>
+                            <Weight>3.000000</Weight>
+                        </Marker>
+                        <Marker Name="marker2">
+                            <Position X="4.000000" Y="5.000000" Z="6.000000"/>
+                            <Weight>7.000000</Weight>
+                        </Marker>
+                    </Markers>
+                    <RigidBodies/>
+                </Segment>
+            </Segments>
+        </Skeleton>
+    </Skeletons>
+</QTM_Settings>
+)XMLDATA";
+
     inline const char* SkeletonSettingsSet = R"XMLDATA(
 <QTM_Settings>
     <Skeletons>

--- a/Tests/SkeletonParametersTests.cpp
+++ b/Tests/SkeletonParametersTests.cpp
@@ -86,11 +86,11 @@ namespace
     std::vector<CRTProtocol::SSettingsSkeleton> CreateDummySkeletonsNonHierarchical()
     {
         auto segmentsSkeleton1 = std::vector<CRTProtocol::SSettingsSkeletonSegment>({
-            { { 0, 0.0f, 1.0f, 2.0f, 0.707000017f, -0.707000017f, 0.0f, 0.0f }, "segment1", -1, -1 },
-            { { 0, 3.0f, 4.0f, 5.0f, 0.707000017f, 0.707000017f, 0.0f, 0.0f }, "segment3", 0, 1 }
+            { { 1, 0.0f, 1.0f, 2.0f, 0.707000017f, -0.707000017f, 0.0f, 0.0f }, "segment1", -1, -1 },
+            { { 3, 3.0f, 4.0f, 5.0f, 0.707000017f, 0.707000017f, 0.0f, 0.0f }, "segment3", 0, 1 }
         });
         auto segmentsSkeleton2 = std::vector<CRTProtocol::SSettingsSkeletonSegment>({
-            { { 0, 0.0f, 1.0f, 2.0f, 0.707000017f, 0.0f, 0.707000017f, 0.0f }, "segment2", -1, -1 }
+            { { 2, 0.0f, 1.0f, 2.0f, 0.707000017f, 0.0f, 0.707000017f, 0.0f }, "segment2", -1, -1 }
         });
 
         CRTProtocol::SSettingsSkeleton skeleton1 = { "skeleton1", segmentsSkeleton1 };
@@ -144,7 +144,7 @@ TEST_CASE("GetSkeletonSettings")
 {
     auto [protocol, network] = utils::CreateTestContext();
 
-    network->PrepareResponse("GetParameters Skeleton", data::SkeletonSettingsSet,
+    network->PrepareResponse("GetParameters Skeleton", data::SkeletonSettingsGet,
                              CRTPacket::PacketXML);
 
     using namespace qualisys_cpp_sdk::tests;
@@ -166,6 +166,7 @@ TEST_CASE("GetSkeletonSettings")
                           const CRTProtocol::SSettingsSkeletonSegmentHierarchical& actualSegment)
     {
         CHECK_EQ(expectedSegment.name, actualSegment.name);
+        CHECK_EQ(expectedSegment.id, actualSegment.id);
 
         CHECK_EQ(expectedSegment.segments.size(), actualSegment.segments.size());
 
@@ -256,7 +257,7 @@ TEST_CASE("GetSkeletonSettingsNonHierarchical")
 {
     auto [protocol, network] = utils::CreateTestContext();
 
-    network->PrepareResponse("GetParameters Skeleton", data::SkeletonSettingsSet,
+    network->PrepareResponse("GetParameters Skeleton", data::SkeletonSettingsGet,
         CRTPacket::PacketXML);
 
     using namespace qualisys_cpp_sdk::tests;


### PR DESCRIPTION
#109 introduces an issue in the skeleton settings xml parser where segment IDs are not correctly recognized and defaults to 0.

This PR fixes the issue. It also includes an update to the test, and new test data.
