### PR TITLE
Add System Live Time mode to Measurement Time port (RTProtocol v1.28)

### DIFF
--- a/RTClientExample/Input.cpp
+++ b/RTClientExample/Input.cpp
@@ -800,6 +800,21 @@ void CInput::ReadCameraSyncOutSettings(unsigned int& nCameraId, int& portNumber,
     }
     else if (portNumber == 3)
     {
+        printf("Enter Mode :\n");
+        printf("  1 : Measurement Time\n");
+        printf("  2 : System Live Time\n");
+        printf("Select 1 - 2 : ");
+        nSyncOutMode = ReadNewCharAsInt('1', true);
+        *nSyncOutMode -= static_cast<int>('0');
+        if (*nSyncOutMode == 2)
+        {
+            *nSyncOutMode = static_cast<int>(CRTProtocol::ESyncOutFreqMode::ModeSystemLiveTime);
+        }
+        else
+        {
+            *nSyncOutMode = static_cast<int>(CRTProtocol::ESyncOutFreqMode::ModeMeasurementTime);
+        }
+
         bSyncOutNegativePolarity = ReadNewYesNo("Negative Polarity? (y/n): ", true);
     }
 }

--- a/RTClientExample/OutputSettings.cpp
+++ b/RTClientExample/OutputSettings.cpp
@@ -473,6 +473,17 @@ void COutput::PrintGeneralSettings(CRTProtocol* poRTProtocol)
                     }
                     if (portNumber == 3)
                     {
+                        switch (eSyncOutMode)
+                        {
+                        case CRTProtocol::ESyncOutFreqMode::ModeMeasurementTime:
+                            printf("  Sync Out MT Mode: Measurement Time\n");
+                            break;
+                        case CRTProtocol::ESyncOutFreqMode::ModeSystemLiveTime:
+                            printf("  Sync Out MT Mode: System Live Time\n");
+                            break;
+                        default:
+                            break;
+                        }
                         printf("  Sync Out MT Signal Polarity: %s\n", bSyncOutNegativePolarity ? "Negative" : "Positive");
                     }
                 }

--- a/RTClientExample/RTClientExample.cpp
+++ b/RTClientExample/RTClientExample.cpp
@@ -1,7 +1,7 @@
 #include "Operations.h"
 
 #define LATEST_SELECTABLE_MAJOR_VERSION 1
-#define LATEST_SELECTABLE_MINOR_VERSION 27
+#define LATEST_SELECTABLE_MINOR_VERSION 28
 #define PROGRAM_VERSION 0
 
 int main(int argc, char **argv)

--- a/RTPacket.h
+++ b/RTPacket.h
@@ -14,7 +14,7 @@
 #endif
 
 #define MAJOR_VERSION           1
-#define MINOR_VERSION           27
+#define MINOR_VERSION           28
 
 class DLL_EXPORT CRTPacket
 {

--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -2072,6 +2072,11 @@ bool CRTProtocol::GetCameraSyncOutSettings(
             nSyncOutValue = mGeneralSettings.vsCameras[nCameraIndex].nSyncOutValue[portNumber - 1];
             fSyncOutDutyCycle = mGeneralSettings.vsCameras[nCameraIndex].fSyncOutDutyCycle[portNumber - 1];
         }
+        else if (portNumber == 3)
+        {
+            // Measurement Time port: only the mode (ModeMeasurementTime or ModeSystemLiveTime) and polarity apply.
+            eSyncOutMode = mGeneralSettings.vsCameras[nCameraIndex].eSyncOutMode[portNumber - 1];
+        }
         if (portNumber > 0 && portNumber < 4)
         {
             bSyncOutNegativePolarity = mGeneralSettings.vsCameras[nCameraIndex].bSyncOutNegativePolarity[portNumber - 1];

--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -2074,7 +2074,7 @@ bool CRTProtocol::GetCameraSyncOutSettings(
         }
         else if (portNumber == 3)
         {
-            // Measurement Time port: only the mode (ModeMeasurementTime or ModeSystemLiveTime) and polarity apply.
+            // Measurement Time port only supports mode and polarity
             eSyncOutMode = mGeneralSettings.vsCameras[nCameraIndex].eSyncOutMode[portNumber - 1];
         }
         if (portNumber > 0 && portNumber < 4)

--- a/Settings.h
+++ b/Settings.h
@@ -206,7 +206,7 @@ namespace qualisys_cpp_sdk
         unsigned int nVideoFOVTop;             // Pixels
         unsigned int nVideoFOVRight;           // Pixels
         unsigned int nVideoFOVBottom;          // Pixels
-        ESyncOutFreqMode eSyncOutMode[3];       // Index 2 (Measurement Time port) only takes ModeMeasurementTime or ModeSystemLiveTime
+        ESyncOutFreqMode eSyncOutMode[3];
         unsigned int nSyncOutValue[2];
         float        fSyncOutDutyCycle[2];     // Percent
         bool         bSyncOutNegativePolarity[3];

--- a/Settings.h
+++ b/Settings.h
@@ -206,7 +206,7 @@ namespace qualisys_cpp_sdk
         unsigned int nVideoFOVTop;             // Pixels
         unsigned int nVideoFOVRight;           // Pixels
         unsigned int nVideoFOVBottom;          // Pixels
-        ESyncOutFreqMode eSyncOutMode[2];
+        ESyncOutFreqMode eSyncOutMode[3];       // Index 2 (Measurement Time port) only takes ModeMeasurementTime or ModeSystemLiveTime
         unsigned int nSyncOutValue[2];
         float        fSyncOutDutyCycle[2];     // Percent
         bool         bSyncOutNegativePolarity[3];

--- a/SettingsDeserializer.cpp
+++ b/SettingsDeserializer.cpp
@@ -821,6 +821,31 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
                         }
                     }
                 }
+                else  // Measurement Time port
+                {
+                    // <Mode> is optional for back-compat with QTM <= 1.27 (older QTM omits this element).
+                    std::string syncOutMode;
+                    if (syncOutElem.TryReadElementString("Mode", syncOutMode))
+                    {
+                        syncOutMode = ToLowerXmlString(syncOutMode);
+                        if (syncOutMode == "measurement time")
+                        {
+                            cameraSettings.eSyncOutMode[port] = ModeMeasurementTime;
+                        }
+                        else if (syncOutMode == "system live time")
+                        {
+                            cameraSettings.eSyncOutMode[port] = ModeSystemLiveTime;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        cameraSettings.eSyncOutMode[port] = ModeMeasurementTime;
+                    }
+                }
 
                 if (port == 2 || (cameraSettings.eSyncOutMode[port] != ModeFixed100Hz))
                 {
@@ -837,9 +862,16 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
             }
             else
             {
-                cameraSettings.eSyncOutMode[port] = ModeIndependentFreq;
-                cameraSettings.nSyncOutValue[port] = 0;
-                cameraSettings.fSyncOutDutyCycle[port] = 0;
+                if (port < 2)
+                {
+                    cameraSettings.eSyncOutMode[port] = ModeIndependentFreq;
+                    cameraSettings.nSyncOutValue[port] = 0;
+                    cameraSettings.fSyncOutDutyCycle[port] = 0;
+                }
+                else
+                {
+                    cameraSettings.eSyncOutMode[port] = ModeMeasurementTime;
+                }
                 cameraSettings.bSyncOutNegativePolarity[port] = false;
             }
         }

--- a/SettingsDeserializer.cpp
+++ b/SettingsDeserializer.cpp
@@ -823,9 +823,8 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
                 }
                 else  // Measurement Time port
                 {
-                    // <Mode> is optional for back-compat with QTM <= 1.27 (older QTM omits this element).
                     std::string syncOutMode;
-                    if (syncOutElem.TryReadElementString("Mode", syncOutMode))
+                    if (syncOutElem.TryReadElementString("Mode", syncOutMode))  // <Mode> is optional (back-compatability with QTM <= 1.27
                     {
                         syncOutMode = ToLowerXmlString(syncOutMode);
                         if (syncOutMode == "measurement time")

--- a/SettingsSerializer.cpp
+++ b/SettingsSerializer.cpp
@@ -419,6 +419,21 @@ std::string SettingsSerializer::SetCameraSyncOutSettings(const unsigned int came
                 }
             }
         }
+        else if (port == 2 && syncOutMode)
+        {
+            // Measurement Time port only accepts ModeMeasurementTime or ModeSystemLiveTime.
+            switch (*syncOutMode)
+            {
+            case ModeMeasurementTime:
+                syncOutElem.ElementString("Mode", "Measurement time");
+                break;
+            case ModeSystemLiveTime:
+                syncOutElem.ElementString("Mode", "System live time");
+                break;
+            default:
+                return "";
+            }
+        }
 
         if (syncOutNegativePolarity && (port == 2 ||
             (syncOutMode && *syncOutMode != ModeFixed100Hz)))

--- a/SettingsSerializer.cpp
+++ b/SettingsSerializer.cpp
@@ -421,7 +421,6 @@ std::string SettingsSerializer::SetCameraSyncOutSettings(const unsigned int came
         }
         else if (port == 2 && syncOutMode)
         {
-            // Measurement Time port only accepts ModeMeasurementTime or ModeSystemLiveTime.
             switch (*syncOutMode)
             {
             case ModeMeasurementTime:


### PR DESCRIPTION
# TL;DR
Updated the SDK to read/write a `<Mode>` element for the **Measurement Time port** (_**Measurement time** or **System live time**_).

# Problem
QTM exposes the ability to set the mode for **Measurement Time port** (_previously only **Measurement Time**, now also **System Live Time**_), but the SDK has no way to interact with this.

# Solution
- Bump version 1.27 -> 1.28
- Grow `SSettingsGeneralCamera::eSyncOutMode` to size 3 so port 3 carries its own mode
- Read/write `<Mode>` for `<Sync_Out_MT>`, restricted to Measurement time or System live time (missing `<Mode>` defaults to `ModeMeasurementTime`)
- `GetCameraSyncOutSettings` accepts `portNumber == 3` for mode access
- Updated **RTClientExample** to print the **MT-port** mode in **View Settings** and prompt for it in **Set Sync Out Settings**