### PR TITLE
Add v1.27 to List of Supported Versions

### DIFF
--- a/RTProtocol.cpp
+++ b/RTProtocol.cpp
@@ -52,6 +52,7 @@ namespace
             // Valid versions added from high to low
             std::vector<RTVersion> versions {
                 {MAJOR_VERSION, MINOR_VERSION},
+                {1, 27},
                 {1, 26},
                 {1, 25},
                 {1, 24},


### PR DESCRIPTION
# TL;DR
Added v1.27 to list of valid versions.

# Problem
Now that we've bumped to version 1.28, the previous version 1.27 wasn't added to the list of valid versions.

# Solution
Added version 1.27 to `std::vector<RTVersion> versions` in **RTProtocol.cpp**.