### PR TITLE
 Measurement Time Port 'Mode' Tests

### DIFF
--- a/SettingsDeserializer.cpp
+++ b/SettingsDeserializer.cpp
@@ -824,7 +824,7 @@ bool SettingsDeserializer::DeserializeGeneralSettings(SSettingsGeneral& generalS
                 else  // Measurement Time port
                 {
                     std::string syncOutMode;
-                    if (syncOutElem.TryReadElementString("Mode", syncOutMode))  // <Mode> is optional (back-compatability with QTM <= 1.27
+                    if (syncOutElem.TryReadElementString("Mode", syncOutMode))  // <Mode> is optional (back-compatibility with QTM <= 1.27)
                     {
                         syncOutMode = ToLowerXmlString(syncOutMode);
                         if (syncOutMode == "measurement time")

--- a/Tests/Data/General.h
+++ b/Tests/Data/General.h
@@ -88,6 +88,34 @@ R"XMLDATA(<QTM_Settings>
 </QTM_Settings>
 )XMLDATA";
 
+    inline const char* SetCameraSyncOutSettingsMTMeasurementTimeTest =
+R"XMLDATA(<QTM_Settings>
+    <General>
+        <Camera>
+            <ID>7</ID>
+            <Sync_Out_MT>
+                <Mode>Measurement time</Mode>
+                <Signal_Polarity>Positive</Signal_Polarity>
+            </Sync_Out_MT>
+        </Camera>
+    </General>
+</QTM_Settings>
+)XMLDATA";
+
+    inline const char* SetCameraSyncOutSettingsMTSystemLiveTimeTest =
+R"XMLDATA(<QTM_Settings>
+    <General>
+        <Camera>
+            <ID>7</ID>
+            <Sync_Out_MT>
+                <Mode>System live time</Mode>
+                <Signal_Polarity>Negative</Signal_Polarity>
+            </Sync_Out_MT>
+        </Camera>
+    </General>
+</QTM_Settings>
+)XMLDATA";
+
     inline const char* SetCameraLensControlSettingsTest =
 R"XMLDATA(<QTM_Settings>
     <General>

--- a/Tests/GeneralParametersTests.cpp
+++ b/Tests/GeneralParametersTests.cpp
@@ -385,7 +385,7 @@ TEST_CASE("GetCameraSyncOutSettingsTest")
     CHECK_EQ(true, bSyncOutNegativePolarity);
 
     // Measurement Time port (port 3) — fixture omits <Mode>, so the deserializer
-    // must default to ModeMeasurementTime (back-compat with QTM <= 1.27).
+    // must default to ModeMeasurementTime (backwards-compatibility with QTM <= 1.27).
     portNumber = 3u;
     eSyncOutMode = CRTProtocol::ESyncOutFreqMode::ModeDivisor;
     bSyncOutNegativePolarity = false;

--- a/Tests/GeneralParametersTests.cpp
+++ b/Tests/GeneralParametersTests.cpp
@@ -311,6 +311,50 @@ TEST_CASE("SetCameraSyncOutSettingsTest")
     CHECK(utils::CompareXmlIgnoreWhitespace(qualisys_cpp_sdk::tests::data::SetCameraSyncOutSettingsTest, network->ReadSentData().data()));
 }
 
+TEST_CASE("SetCameraSyncOutSettingsMTMeasurementTimeTest")
+{
+    auto [protocol, network] = utils::CreateTestContext();
+
+    network->PrepareResponse("<QTM_Settings>", "Setting parameters succeeded", CRTPacket::PacketCommand);
+
+    const unsigned int nCameraID = 7u;
+    const unsigned int portNumber = 3u;
+    const CRTProtocol::ESyncOutFreqMode peSyncOutMode = CRTProtocol::ESyncOutFreqMode::ModeMeasurementTime;
+    const bool pbSyncOutNegativePolarity = false;
+
+    if (!protocol->SetCameraSyncOutSettings(
+        nCameraID, portNumber, &peSyncOutMode,
+        nullptr, nullptr,
+        &pbSyncOutNegativePolarity))
+    {
+        FAIL(protocol->GetErrorString());
+    }
+
+    CHECK(utils::CompareXmlIgnoreWhitespace(qualisys_cpp_sdk::tests::data::SetCameraSyncOutSettingsMTMeasurementTimeTest, network->ReadSentData().data()));
+}
+
+TEST_CASE("SetCameraSyncOutSettingsMTSystemLiveTimeTest")
+{
+    auto [protocol, network] = utils::CreateTestContext();
+
+    network->PrepareResponse("<QTM_Settings>", "Setting parameters succeeded", CRTPacket::PacketCommand);
+
+    const unsigned int nCameraID = 7u;
+    const unsigned int portNumber = 3u;
+    const CRTProtocol::ESyncOutFreqMode peSyncOutMode = CRTProtocol::ESyncOutFreqMode::ModeSystemLiveTime;
+    const bool pbSyncOutNegativePolarity = true;
+
+    if (!protocol->SetCameraSyncOutSettings(
+        nCameraID, portNumber, &peSyncOutMode,
+        nullptr, nullptr,
+        &pbSyncOutNegativePolarity))
+    {
+        FAIL(protocol->GetErrorString());
+    }
+
+    CHECK(utils::CompareXmlIgnoreWhitespace(qualisys_cpp_sdk::tests::data::SetCameraSyncOutSettingsMTSystemLiveTimeTest, network->ReadSentData().data()));
+}
+
 TEST_CASE("GetCameraSyncOutSettingsTest")
 {
     auto [protocol, network] = utils::CreateTestContext();
@@ -339,6 +383,63 @@ TEST_CASE("GetCameraSyncOutSettingsTest")
     CHECK_EQ(1, nSyncOutValue);
     CHECK_EQ(50.0f, fSyncOutDutyCycle);
     CHECK_EQ(true, bSyncOutNegativePolarity);
+
+    // Measurement Time port (port 3) — fixture omits <Mode>, so the deserializer
+    // must default to ModeMeasurementTime (back-compat with QTM <= 1.27).
+    portNumber = 3u;
+    eSyncOutMode = CRTProtocol::ESyncOutFreqMode::ModeDivisor;
+    bSyncOutNegativePolarity = false;
+
+    protocol->GetCameraSyncOutSettings(
+        nCameraIndex, portNumber, eSyncOutMode,
+        nSyncOutValue, fSyncOutDutyCycle,
+        bSyncOutNegativePolarity
+    );
+
+    CHECK_EQ(CRTProtocol::ESyncOutFreqMode::ModeMeasurementTime, eSyncOutMode);
+    CHECK_EQ(true, bSyncOutNegativePolarity);
+}
+
+TEST_CASE("GetCameraSyncOutSettingsMTSystemLiveTimeTest")
+{
+    auto [protocol, network] = utils::CreateTestContext();
+
+    std::string xml = qualisys_cpp_sdk::tests::data::GetGeneralSettingsTest;
+    const std::string oldBlock =
+        "<Sync_Out_MT>\n"
+        "                <Signal_Polarity>Negative</Signal_Polarity>\n"
+        "            </Sync_Out_MT>";
+    const std::string newBlock =
+        "<Sync_Out_MT>\n"
+        "                <Mode>System live time</Mode>\n"
+        "                <Signal_Polarity>Positive</Signal_Polarity>\n"
+        "            </Sync_Out_MT>";
+    auto pos = xml.find(oldBlock);
+    REQUIRE(pos != std::string::npos);
+    xml.replace(pos, oldBlock.length(), newBlock);
+
+    network->PrepareResponse("GetParameters General", xml.c_str(), CRTPacket::PacketXML);
+
+    if (!protocol->ReadGeneralSettings())
+    {
+        FAIL(protocol->GetErrorString());
+    }
+
+    unsigned int nCameraIndex = 7u;
+    unsigned int portNumber = 3u;
+    CRTProtocol::ESyncOutFreqMode eSyncOutMode = CRTProtocol::ESyncOutFreqMode::ModeDivisor;
+    unsigned int nSyncOutValue = 99u;
+    float fSyncOutDutyCycle = 99.0f;
+    bool bSyncOutNegativePolarity = true;
+
+    protocol->GetCameraSyncOutSettings(
+        nCameraIndex, portNumber, eSyncOutMode,
+        nSyncOutValue, fSyncOutDutyCycle,
+        bSyncOutNegativePolarity
+    );
+
+    CHECK_EQ(CRTProtocol::ESyncOutFreqMode::ModeSystemLiveTime, eSyncOutMode);
+    CHECK_EQ(false, bSyncOutNegativePolarity);
 }
 
 TEST_CASE("SetCameraLensControlSettingsTest")


### PR DESCRIPTION
# TL;DR
Added test coverage for `<Sync_Out_MT>` `<Mode>`.

# Problem
The new `<Sync_Out_MT>` `<Mode>` recently added with v1.28 doesn't have any test coverage.

# Solution
- Added **3 new tests** in `Tests/GeneralParametersTests.cpp`:
  - `SetCameraSyncOutSettingsMTMeasurementTimeTest`
  - `SetCameraSyncOutSettingsMTSystemLiveTimeTest`
  - `GetCameraSyncOutSettingsMTSystemLiveTimeTest`
- Extended `GetCameraSyncOutSettingsTest` with a port-3 read against the existing fixture (_no `<Mode>` element, tests backwards-compatibility with QTM ≤ 1.27_)
- Added **2 new fixtures** in `Tests/Data/General.h`
  - Deserializer test reuses `GetGeneralSettingsTest` via in-place string substitution (_avoids duplicating ~625 lines of XML_)

# Extra
- Fixed typo in `SettingsDeserializer.cpp:827`: back-compatability -> **back-compatibility**

# Tests
- CMake configure + build
- `ctest` (35/35 tests passing)